### PR TITLE
Added basic structured address parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ PROJECT ( libcitygml )
 
 set(META_VERSION_MAJOR       "1")
 set(META_VERSION_MINOR       "4")
-set(META_VERSION_PATCH       "0")
+set(META_VERSION_PATCH       "2")
 set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
 
 SET( CMAKE_MODULE_PATH "${libcitygml_SOURCE_DIR}/CMakeModules/;${CMAKE_MODULE_PATH}" )

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -41,6 +41,7 @@ SET(SOURCES
   src/citygml/polygonmanager.cpp
   src/citygml/geometrymanager.cpp
   src/citygml/linestring.cpp
+  src/citygml/address.cpp
 
   src/parser/nodetypes.cpp
   src/parser/attributes.cpp
@@ -70,6 +71,7 @@ SET(SOURCES
   src/parser/linestringelementparser.cpp
   src/parser/linearringelementparser.cpp
   src/parser/implicitgeometryelementparser.cpp
+  src/parser/addressparser.cpp
 )
 
 SET(PUBLIC_HEADER
@@ -99,6 +101,7 @@ SET(PUBLIC_HEADER
   include/citygml/appearancetarget.h
   include/citygml/citygmlfactory.h
   include/citygml/linestring.h
+  include/citygml/address.h
 )
 
 SET(HEADERS
@@ -141,6 +144,7 @@ SET(HEADERS
   include/parser/linestringelementparser.h
   include/parser/linearringelementparser.h
   include/parser/implicitgeometryelementparser.h
+  include/parser/addressparser.h
 )
 
 ADD_LIBRARY( ${target} ${LIBCITYGML_USER_DEFINED_DYNAMIC_OR_STATIC} ${SOURCES} ${HEADERS} )

--- a/sources/include/citygml/address.h
+++ b/sources/include/citygml/address.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <citygml/citygml_api.h>
+#include <citygml/object.h>
+
+namespace citygml {
+
+    class LIBCITYGML_EXPORT Address: public Object
+    {
+    public:
+        Address(const std::string& id);
+
+        const std::string& country() const;
+        void setCountry(const std::string& country);
+
+        const std::string& locality() const;
+        void setLocality(const std::string& locality);
+
+        const std::string& postalCode() const;
+        void setPostalCode(const std::string& postalCode);
+
+        const std::string& thoroughfareName() const;
+        void setThoroughfareName(const std::string& thoroughfareName);
+
+        const std::string& thoroughfareNumber() const;
+        void setThoroughfareNumber(const std::string& thoroughfareNumber);
+
+    protected:
+        std::string m_country;
+        std::string m_locality;
+        std::string m_thoroughfareName;
+        std::string m_thoroughfareNumber;
+        std::string m_postalCode;
+    };
+
+} /* namespace citygml */

--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -16,6 +16,7 @@ namespace citygml {
     class Composite;
     class CityGMLLogger;
     class AppearanceManager;
+    class Address;
 
     class LIBCITYGML_EXPORT CityObject : public FeatureObject
     {
@@ -88,12 +89,14 @@ namespace citygml {
 
         // Access the children
         unsigned int getChildCityObjectsCount() const;
-
         const CityObject& getChildCityObject( unsigned int i ) const;
-
         CityObject& getChildCityObject( unsigned int i );
 
         void addChildCityObject(CityObject* cityObj);
+
+        // Access address
+        const Address* address() const;
+        void setAddress(std::unique_ptr<Address>&& address);
 
         void finish(Tesselator& tesselator, bool optimize, std::shared_ptr<citygml::CityGMLLogger> logger);
 
@@ -105,6 +108,7 @@ namespace citygml {
         std::vector<std::unique_ptr<Geometry>> m_geometries;
         std::vector<std::unique_ptr<ImplicitGeometry>> m_implicitGeometries;
         std::vector<std::unique_ptr<CityObject>> m_children;
+        std::unique_ptr<Address> m_address;
     };
 
     std::ostream& operator<<( std::ostream& os, const CityObject& o );

--- a/sources/include/parser/addressparser.h
+++ b/sources/include/parser/addressparser.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <parser/citygmlelementparser.h>
+
+namespace citygml {
+
+    class Address;
+
+    class AddressParser: public CityGMLElementParser {
+    public:
+        using Callback = std::function<void(std::unique_ptr<Address>&&)>;
+
+    public:
+        AddressParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger, const Callback& callback);
+
+        virtual std::string elementParserName() const override;
+        virtual bool handlesElement(const NodeType::XMLNode& node) const override;
+
+    protected:
+        virtual bool parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes ) override;
+        virtual bool parseElementEndTag(const NodeType::XMLNode& node, const std::string& characters ) override;
+        virtual bool parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes ) override;
+        virtual bool parseChildElementEndTag(const NodeType::XMLNode& node, const std::string& characters ) override;
+
+
+    protected:
+        std::unique_ptr<Address> m_address;
+        Callback m_callback;
+    };
+
+} /* namespace citygml */

--- a/sources/include/parser/nodetypes.h
+++ b/sources/include/parser/nodetypes.h
@@ -53,6 +53,7 @@ namespace citygml {
         NODETYPE( CORE, Name)
 
         NODETYPE( CORE, Address )
+        NODETYPE( CORE, XalAddress )
 
         NODETYPE( CORE, ImplicitGeometry )
         NODETYPE( CORE, RelativeGMLGeometry )
@@ -228,21 +229,19 @@ namespace citygml {
         NODETYPE( FRN, Lod4ImplicitRepresentation )
 
         // ADDRESS
-        NODETYPE( XAL, XalAddress )
-        NODETYPE( XAL, Administrativearea )
+        NODETYPE( XAL, AddressDetails )
         NODETYPE( XAL, Country )
         NODETYPE( XAL, CountryName )
-        NODETYPE( XAL, Code )
-        NODETYPE( XAL, Street )
-        NODETYPE( XAL, PostalCode )
-        NODETYPE( XAL, City )
-        NODETYPE( XAL, LocalityName )
-        NODETYPE( XAL, Thoroughfare )
-        NODETYPE( XAL, ThoroughfareNumber )
-        NODETYPE( XAL, ThoroughfareName )
+        NODETYPE( XAL, CountryNameCode )
+        NODETYPE( XAL, AdministrativeArea )
+        NODETYPE( XAL, AdministrativeAreaName )
         NODETYPE( XAL, Locality )
-        NODETYPE( XAL, AddressDetails )
-        NODETYPE( XAL, DependentLocalityName )
+        NODETYPE( XAL, LocalityName )
+        NODETYPE( XAL, PostalCode )
+        NODETYPE( XAL, PostalCodeNumber )
+        NODETYPE( XAL, Thoroughfare )
+        NODETYPE( XAL, ThoroughfareName )
+        NODETYPE( XAL, ThoroughfareNumber )
 
         // WTR
         NODETYPE( WTR, WaterBody )
@@ -393,3 +392,23 @@ namespace citygml {
 
     std::ostream& operator<<( std::ostream& os, const NodeType::XMLNode& o );
 }
+
+namespace std {
+
+template <>
+struct hash<citygml::NodeType::XMLNode> {
+    size_t operator()(const citygml::NodeType::XMLNode& node) const
+    {
+        return node.typeID();
+    }
+};
+
+template <>
+struct hash<const citygml::NodeType::XMLNode&> {
+    size_t operator()(const citygml::NodeType::XMLNode& node) const
+    {
+        return node.typeID();
+    }
+};
+
+}  // namespace std

--- a/sources/src/citygml/address.cpp
+++ b/sources/src/citygml/address.cpp
@@ -1,0 +1,50 @@
+#include <citygml/address.h>
+
+namespace citygml {
+
+    Address::Address(const std::string& id)
+    : Object(id)
+    {
+    }
+
+    const std::string& Address::country() const {
+        return m_country;
+    }
+
+    void Address::setCountry(const std::string& country) {
+        m_country = country;
+    }
+
+    const std::string& Address::locality() const {
+        return m_locality;
+    }
+
+    void Address::setLocality(const std::string& locality) {
+        m_locality = locality;
+    }
+
+    const std::string& Address::postalCode() const {
+        return m_postalCode;
+    }
+
+    void Address::setPostalCode(const std::string& postalCode) {
+        m_postalCode = postalCode;
+    }
+
+    const std::string& Address::thoroughfareName() const {
+        return m_thoroughfareName;
+    }
+
+    void Address::setThoroughfareName(const std::string& thoroughfareName) {
+        m_thoroughfareName = thoroughfareName;
+    }
+
+    const std::string& Address::thoroughfareNumber() const {
+        return m_thoroughfareNumber;
+    }
+
+    void Address::setThoroughfareNumber(const std::string& thoroughfareNumber) {
+        m_thoroughfareNumber = thoroughfareNumber;
+    }
+
+} /* namespace citygml */

--- a/sources/src/citygml/cityobject.cpp
+++ b/sources/src/citygml/cityobject.cpp
@@ -4,6 +4,7 @@
 #include "citygml/appearancemanager.h"
 #include "citygml/citygml.h"
 #include "citygml/citygmllogger.h"
+#include "citygml/address.h"
 
 #include <unordered_map>
 #include <algorithm>
@@ -83,6 +84,16 @@ namespace citygml {
     void CityObject::addChildCityObject(CityObject* cityObj)
     {
         m_children.push_back(std::unique_ptr<CityObject>(cityObj));
+    }
+
+    const Address* CityObject::address() const
+    {
+        return m_address.get();
+    }
+
+    void CityObject::setAddress(std::unique_ptr<Address>&& address)
+    {
+        m_address = std::move(address);
     }
 
     void CityObject::finish(Tesselator& tesselator, bool optimize, std::shared_ptr<CityGMLLogger> logger)

--- a/sources/src/parser/addressparser.cpp
+++ b/sources/src/parser/addressparser.cpp
@@ -1,0 +1,114 @@
+#include <parser/addressparser.h>
+#include <parser/documentlocation.h>
+#include <parser/attributes.h>
+
+#include <citygml/address.h>
+#include <citygml/citygmllogger.h>
+
+#include <unordered_set>
+#include <unordered_map>
+#include <functional>
+
+namespace citygml {
+
+    namespace {
+
+        template<typename T, typename... Args>
+        std::unique_ptr<T> make_unique(Args&&... args) {
+            return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+        }
+
+        auto k_rootElements = std::unordered_set<NodeType::XMLNode>();
+        auto k_subElements = std::unordered_set<NodeType::XMLNode>();
+        auto k_dataElements = std::unordered_map<NodeType::XMLNode, std::function<void(Address*, const std::string&)>>();
+
+        std::mutex g_nodeSetMutex;
+        bool g_nodeSetsInitialized = false;
+
+        void initializeNodeSets() {
+            if (!g_nodeSetsInitialized) {
+                std::lock_guard<std::mutex> lock(g_nodeSetMutex);
+                if (!g_nodeSetsInitialized) {
+                    k_rootElements = {
+                        NodeType::CORE_AddressNode,
+                        NodeType::BLDG_AddressNode,
+                        NodeType::CORE_XalAddressNode
+                    };
+
+                    k_subElements = {
+                        NodeType::XAL_AddressDetailsNode,
+                        NodeType::XAL_CountryNode,
+                        NodeType::XAL_LocalityNode,
+                        NodeType::XAL_PostalCodeNode,
+                        NodeType::XAL_ThoroughfareNode
+                    };
+
+                    k_dataElements = {
+                        { NodeType::XAL_CountryNameNode, &Address::setCountry },
+                        { NodeType::XAL_LocalityNameNode, &Address::setLocality },
+                        { NodeType::XAL_ThoroughfareNameNode, &Address::setThoroughfareName },
+                        { NodeType::XAL_ThoroughfareNumberNode, &Address::setThoroughfareNumber },
+                        { NodeType::XAL_PostalCodeNumberNode, &Address::setPostalCode }
+                    };
+
+                    g_nodeSetsInitialized = true;
+                }
+            }
+        }
+
+    }  // anonymous namespace
+
+    AddressParser::AddressParser(CityGMLDocumentParser& documentParser, CityGMLFactory& factory, std::shared_ptr<CityGMLLogger> logger, const Callback& callback)
+    : CityGMLElementParser(documentParser, factory, logger)
+    , m_callback(callback)
+    {
+        initializeNodeSets();
+    }
+
+    std::string AddressParser::elementParserName() const
+    {
+        return "AddressParser";
+    }
+
+    bool AddressParser::handlesElement(const NodeType::XMLNode& node) const
+    {
+        return k_rootElements.count(node) > 0
+            || k_subElements.count(node) > 0
+            || k_dataElements.count(node) > 0;
+    }
+
+    bool AddressParser::parseElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
+    {
+        if (k_rootElements.count(node) == 0) {
+            CITYGML_LOG_ERROR(m_logger, "Expected an address start tag but got <" << node << "> at " << getDocumentLocation());
+            throw std::runtime_error("Unexpected start tag found.");
+        }
+
+        m_address = make_unique<Address>(attributes.getCityGMLIDAttribute());
+        return true;
+    }
+
+    bool AddressParser::parseElementEndTag(const NodeType::XMLNode& node, const std::string& characters)
+    {
+        m_callback(std::move(m_address));
+        m_address = nullptr;
+        return k_rootElements.count(node) > 0;
+    }
+
+    bool AddressParser::parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
+    {
+        return handlesElement(node);
+    }
+
+    bool AddressParser::parseChildElementEndTag(const NodeType::XMLNode& node, const std::string& characters)
+    {
+        const auto itr = k_dataElements.find(node);
+        if (itr != k_dataElements.end()) {
+            itr->second(m_address.get(), characters);
+            return true;
+        }
+
+        return handlesElement(node);
+    }
+
+} /* namespace citygml */

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -9,9 +9,11 @@
 #include "parser/skipelementparser.h"
 #include "parser/delayedchoiceelementparser.h"
 #include "parser/linestringelementparser.h"
+#include "parser/addressparser.h"
 
 #include "citygml/citygmlfactory.h"
 #include "citygml/citygmllogger.h"
+#include "citygml/address.h"
 
 #include <stdexcept>
 #include <iostream>
@@ -114,23 +116,6 @@ namespace citygml {
                 attributesSet.insert(HANDLE_ATTR(BLDG, StoreysAboveGround));
                 attributesSet.insert(HANDLE_ATTR(BLDG, MeasuredHeight));
                 attributesSet.insert(HANDLE_ATTR(BLDG, RoofType));
-                attributesSet.insert(HANDLE_ATTR(CORE, Address));
-                attributesSet.insert(HANDLE_ATTR(BLDG, Address));
-                attributesSet.insert(HANDLE_ATTR(XAL, XalAddress));
-                attributesSet.insert(HANDLE_ATTR(XAL, Administrativearea));
-                attributesSet.insert(HANDLE_ATTR(XAL, Country));
-                attributesSet.insert(HANDLE_ATTR(XAL, CountryName));
-                attributesSet.insert(HANDLE_ATTR(XAL, Code));
-                attributesSet.insert(HANDLE_ATTR(XAL, Street));
-                attributesSet.insert(HANDLE_ATTR(XAL, PostalCode));
-                attributesSet.insert(HANDLE_ATTR(XAL, City));
-                attributesSet.insert(HANDLE_ATTR(XAL, LocalityName));
-                attributesSet.insert(HANDLE_ATTR(XAL, Thoroughfare));
-                attributesSet.insert(HANDLE_ATTR(XAL, ThoroughfareNumber));
-                attributesSet.insert(HANDLE_ATTR(XAL, ThoroughfareName));
-                attributesSet.insert(HANDLE_ATTR(XAL, Locality));
-                attributesSet.insert(HANDLE_ATTR(XAL, AddressDetails));
-                attributesSet.insert(HANDLE_ATTR(XAL, DependentLocalityName));
                 attributesSet.insert(HANDLE_ATTR(VEG, Class ));
                 attributesSet.insert(HANDLE_ATTR(VEG, Function ));
                 attributesSet.insert(HANDLE_ATTR(VEG, AverageHeight ));
@@ -334,7 +319,13 @@ namespace citygml {
             CITYGML_LOG_INFO(m_logger, "Skipping CityObject child element <" << node  << ">  at " << getDocumentLocation() << " (Currently not supported!)");
             setParserForNextElement(new SkipElementParser(m_documentParser, m_logger, node));
             return true;
-
+        } else if (node == NodeType::BLDG_AddressNode
+                   || node == NodeType::CORE_AddressNode
+                   || node == NodeType::CORE_XalAddressNode) {
+            setParserForNextElement(new AddressParser(m_documentParser, m_factory, m_logger, [this](std::unique_ptr<Address>&& address) {
+                m_model->setAddress(std::move(address));
+            }));
+            return true;
         } else {
             return GMLFeatureCollectionElementParser::parseChildElementStartTag(node, attributes);
         }

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -96,6 +96,7 @@ namespace citygml {
                 INITIALIZE_NODE( CORE, Name)
 
                 INITIALIZE_NODE( CORE, Address )
+                INITIALIZE_NODE( CORE, XalAddress )
 
                 INITIALIZE_NODE( CORE, ImplicitGeometry )
                 INITIALIZE_NODE( CORE, RelativeGMLGeometry )
@@ -270,21 +271,19 @@ namespace citygml {
                 INITIALIZE_NODE( BLDG, Address)
 
                 // ADDRESS
-                INITIALIZE_NODE( XAL, XalAddress )
-                INITIALIZE_NODE( XAL, Administrativearea )
+                INITIALIZE_NODE( XAL, AddressDetails )
                 INITIALIZE_NODE( XAL, Country )
                 INITIALIZE_NODE( XAL, CountryName )
-                INITIALIZE_NODE( XAL, Code )
-                INITIALIZE_NODE( XAL, Street )
-                INITIALIZE_NODE( XAL, PostalCode )
-                INITIALIZE_NODE( XAL, City )
-                INITIALIZE_NODE( XAL, LocalityName )
-                INITIALIZE_NODE( XAL, Thoroughfare )
-                INITIALIZE_NODE( XAL, ThoroughfareNumber )
-                INITIALIZE_NODE( XAL, ThoroughfareName )
+                INITIALIZE_NODE( XAL, CountryNameCode )
+                INITIALIZE_NODE( XAL, AdministrativeArea )
+                INITIALIZE_NODE( XAL, AdministrativeAreaName )
                 INITIALIZE_NODE( XAL, Locality )
-                INITIALIZE_NODE( XAL, AddressDetails )
-                INITIALIZE_NODE( XAL, DependentLocalityName )
+                INITIALIZE_NODE( XAL, LocalityName )
+                INITIALIZE_NODE( XAL, PostalCode )
+                INITIALIZE_NODE( XAL, PostalCodeNumber )
+                INITIALIZE_NODE( XAL, Thoroughfare )
+                INITIALIZE_NODE( XAL, ThoroughfareName )
+                INITIALIZE_NODE( XAL, ThoroughfareNumber )
 
                 // WTR
                 INITIALIZE_NODE( WTR, WaterBody )
@@ -472,6 +471,7 @@ namespace citygml {
     DEFINE_NODE( CORE, Name)
 
     DEFINE_NODE( CORE, Address )
+    DEFINE_NODE( CORE, XalAddress )
 
     DEFINE_NODE( CORE, ImplicitGeometry )
     DEFINE_NODE( CORE, RelativeGMLGeometry )
@@ -648,21 +648,19 @@ namespace citygml {
     DEFINE_NODE( BLDG, Address)
 
     // ADDRESS
-    DEFINE_NODE( XAL, XalAddress )
-    DEFINE_NODE( XAL, Administrativearea )
+    DEFINE_NODE( XAL, AddressDetails )
     DEFINE_NODE( XAL, Country )
     DEFINE_NODE( XAL, CountryName )
-    DEFINE_NODE( XAL, Code )
-    DEFINE_NODE( XAL, Street )
-    DEFINE_NODE( XAL, PostalCode )
-    DEFINE_NODE( XAL, City )
-    DEFINE_NODE( XAL, LocalityName )
-    DEFINE_NODE( XAL, Thoroughfare )
-    DEFINE_NODE( XAL, ThoroughfareNumber )
-    DEFINE_NODE( XAL, ThoroughfareName )
+    DEFINE_NODE( XAL, CountryNameCode )
+    DEFINE_NODE( XAL, AdministrativeArea )
+    DEFINE_NODE( XAL, AdministrativeAreaName )
     DEFINE_NODE( XAL, Locality )
-    DEFINE_NODE( XAL, AddressDetails )
-    DEFINE_NODE( XAL, DependentLocalityName )
+    DEFINE_NODE( XAL, LocalityName )
+    DEFINE_NODE( XAL, PostalCode )
+    DEFINE_NODE( XAL, PostalCodeNumber )
+    DEFINE_NODE( XAL, Thoroughfare )
+    DEFINE_NODE( XAL, ThoroughfareName )
+    DEFINE_NODE( XAL, ThoroughfareNumber )
 
     // WTR
     DEFINE_NODE( WTR, WaterBody )


### PR DESCRIPTION
Basic parsing of XAL addresses was implemented. This does not support the full flexibility of the address scheme, but should be sufficient to capture the most important address components. Also raised the version number to 1.4.2 showing that several others fixes were applied