### PR TITLE
Fix to issue https://github.com/jklimke/libcitygml/issues/17

### DIFF
--- a/sources/src/citygml/tesselator.cpp
+++ b/sources/src/citygml/tesselator.cpp
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <assert.h>
+#include <algorithm>
 
 Tesselator::Tesselator(std::shared_ptr<citygml::CityGMLLogger> logger )
 {

--- a/sources/src/parser/addressparser.cpp
+++ b/sources/src/parser/addressparser.cpp
@@ -10,6 +10,30 @@
 #include <functional>
 
 namespace citygml {
+	void setCountry(Address* address, std::string const &country)
+	{
+		address->setCountry(country);
+	}
+
+	void setLocality(Address* address, std::string const &locality)
+	{
+		address->setLocality(locality);
+	}
+
+	void setThoroughfareName(Address* address, std::string const &thoroughfareName)
+	{
+		address->setThoroughfareName(thoroughfareName);
+	}
+
+	void setThoroughfareNumber(Address *address, std::string const &thoroughfareNumber)
+	{
+		address->setThoroughfareNumber(thoroughfareNumber);
+	}
+
+	void setPostalCode(Address* address, std::string const &postalCode)
+	{
+		address->setPostalCode(postalCode);
+	}
 
     namespace {
 
@@ -43,13 +67,18 @@ namespace citygml {
                         NodeType::XAL_ThoroughfareNode
                     };
 
-                    k_dataElements = {
-                        { NodeType::XAL_CountryNameNode, &Address::setCountry },
-                        { NodeType::XAL_LocalityNameNode, &Address::setLocality },
-                        { NodeType::XAL_ThoroughfareNameNode, &Address::setThoroughfareName },
-                        { NodeType::XAL_ThoroughfareNumberNode, &Address::setThoroughfareNumber },
-                        { NodeType::XAL_PostalCodeNumberNode, &Address::setPostalCode }
-                    };
+                    //k_dataElements = {
+                    //    { NodeType::XAL_CountryNameNode, &Address::setCountry },
+                    //    { NodeType::XAL_LocalityNameNode, &Address::setLocality },
+                    //    { NodeType::XAL_ThoroughfareNameNode, &Address::setThoroughfareName },
+                    //    { NodeType::XAL_ThoroughfareNumberNode, &Address::setThoroughfareNumber },
+                    //    { NodeType::XAL_PostalCodeNumberNode, &Address::setPostalCode }
+                    //};
+					k_dataElements[NodeType::XAL_CountryNameNode] = &setCountry;
+					k_dataElements[NodeType::XAL_LocalityNameNode] = &setLocality;
+					k_dataElements[NodeType::XAL_ThoroughfareNameNode] = &setThoroughfareName;
+					k_dataElements[NodeType::XAL_ThoroughfareNumberNode] = &setThoroughfareNumber;
+					k_dataElements[NodeType::XAL_PostalCodeNumberNode] = &setPostalCode;
 
                     g_nodeSetsInitialized = true;
                 }
@@ -82,7 +111,7 @@ namespace citygml {
             throw std::runtime_error("Unexpected start tag found.");
         }
 
-        m_address = make_unique<Address>(attributes.getCityGMLIDAttribute());
+        m_address = std::make_unique<Address>(attributes.getCityGMLIDAttribute());
         return true;
     }
 

--- a/sources/src/parser/addressparser.cpp
+++ b/sources/src/parser/addressparser.cpp
@@ -67,13 +67,6 @@ namespace citygml {
                         NodeType::XAL_ThoroughfareNode
                     };
 
-                    //k_dataElements = {
-                    //    { NodeType::XAL_CountryNameNode, &Address::setCountry },
-                    //    { NodeType::XAL_LocalityNameNode, &Address::setLocality },
-                    //    { NodeType::XAL_ThoroughfareNameNode, &Address::setThoroughfareName },
-                    //    { NodeType::XAL_ThoroughfareNumberNode, &Address::setThoroughfareNumber },
-                    //    { NodeType::XAL_PostalCodeNumberNode, &Address::setPostalCode }
-                    //};
 					k_dataElements[NodeType::XAL_CountryNameNode] = &setCountry;
 					k_dataElements[NodeType::XAL_LocalityNameNode] = &setLocality;
 					k_dataElements[NodeType::XAL_ThoroughfareNameNode] = &setThoroughfareName;


### PR DESCRIPTION
With this I got libcitygml to compile getting past the issues described in https://github.com/jklimke/libcitygml/issues/17

Not mentioned there, MSVC was unable to find std::max in tesselator.cpp. I solved that by including <algorithm>, where `std::max` is declared.

The ambiguity of the assignment operator seems to be related to the initializer list. In line 46 there was an assignment, so I'm not convinced, that that was a proper use anyways. Using insertion in the unordered map solved this but created a new problem.

The function signature for `&Address::setCountry` did not match `std::function<void(Address*, const std::string&)>>()`, which is required to insert the function. So I created five functions to get the necessary function signature.

On a related note: As I know it, function pointers to non-static class methods are illegal anyway. Was that a change to C++11 that I missed (and apparently Microsoft too)? Or is this a non standard feature of some compilers?

The last problem (make_unique) probably occurs, because MSVC cannot discern between the anonymous namespace version of make_unique and std::make_unique provided by C++14. My solution was to simply use the std version. But I imagine that to be less than optimal, if you want to stay C++11 compliant. Nonetheless I wanted to share my thoughts on that.

I have one last issue with building in VS2013. Although `XERCES_LIBRARY_DEBUG` points to the correct file in CMake, VS2013 links against the release version. I'm still trying to solve that.