### PR TITLE
add missing return value

### DIFF
--- a/sources/src/citygml/attributesmap.cpp
+++ b/sources/src/citygml/attributesmap.cpp
@@ -103,6 +103,7 @@ int AttributeValue::asInteger(int defaultValue) const
 std::ostream& operator<<(std::ostream& os, const AttributeValue& o)
 {
     os << o.asString();
+    return os;
 }
 
 } // namespace citygml


### PR DESCRIPTION
`attributesmap.cpp` is missing a return value in `operator<<`