### PR TITLE
Use the z coordinate for OGR transform when vertex is TVec3d

### DIFF
--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -58,7 +58,7 @@ public:
             return;
         }
 
-        m_transformation->Transform( 1, &p.x, &p.y );
+        m_transformation->Transform( 1, &p.x, &p.y, &p.z );
     }
 
     void transform( TVec2d &p ) const


### PR DESCRIPTION
Yeah, Z is transformed using a vertical datum. So not transforming the z-coordinate will skew the model.