### PR TITLE
Add support for xerces-c 3.2.

### DIFF
--- a/CMakeModules/FindXerces.cmake
+++ b/CMakeModules/FindXerces.cmake
@@ -29,14 +29,14 @@ ${XERCESC_INCLUDE_DIR}
 )
 
 IF (XERCESC_STATIC)
-FIND_LIBRARY(XERCESC_LIBRARY NAMES xerces-c_static_3 xerces-c-3.1 xerces-c
+FIND_LIBRARY(XERCESC_LIBRARY NAMES xerces-c_static_3 xerces-c-3.2 xerces-c-3.1 xerces-c
  PATHS
  $ENV{XERCESC_LIBRARY_DIR}
  ${XERCESC_LIBRARY_DIR}
  /usr/lib
  /usr/local/lib
 )
-FIND_LIBRARY(XERCESC_LIBRARY_DEBUG NAMES xerces-c_static_3D xerces-c-3.1D
+FIND_LIBRARY(XERCESC_LIBRARY_DEBUG NAMES xerces-c_static_3D xerces-c-3.2D xerces-c-3.1D
  PATHS
  $ENV{XERCESC_LIBRARY_DIR}
  ${XERCESC_LIBRARY_DIR}


### PR DESCRIPTION
The initial patch was provided by Matthias Klose in [Debian Bug #881924](https://bugs.debian.org/881924), but that replaced 3.1 support with 3.2 instead of adding support for 3.2.