### PR TITLE
Add a source SRS CLI option

### DIFF
--- a/sources/include/citygml/citygml.h
+++ b/sources/include/citygml/citygml.h
@@ -59,6 +59,7 @@ namespace citygml
     // pruneEmptyObjects: remove the objects which do not contains any geometrical entity
     // tesselate: convert the interior & exteriors polygons to triangles
     // destSRS: the SRS (WKT, EPSG, OGC URN, etc.) where the coordinates must be transformed, default ("") is no transformation
+    // srsSRS: the SRS (WKT, EPSG, OGC URN, etc.) to overrride the SRS in the CityGML data (if any), default ("") means no override or use included SRS
 
     class LIBCITYGML_EXPORT ParserParams
     {
@@ -70,6 +71,7 @@ namespace citygml
             , optimize( false )
             , pruneEmptyObjects( false )
             , destSRS( "" )
+            , srcSRS( "" )
             , keepVertices ( false )
         { }
 
@@ -82,6 +84,7 @@ namespace citygml
         bool tesselate;
         bool keepVertices;
         std::string destSRS;
+        std::string srcSRS;
     };
 
     LIBCITYGML_EXPORT std::shared_ptr<const CityModel> load( std::istream& stream, const ParserParams& params, std::shared_ptr<CityGMLLogger> logger = nullptr);

--- a/sources/include/parser/citygmldocumentparser.h
+++ b/sources/include/parser/citygmldocumentparser.h
@@ -19,6 +19,8 @@ namespace citygml {
 
         std::shared_ptr<const CityModel> getModel();
 
+        const ParserParams getParserParams() const;
+
         // Methods used by CityGMLElementParser
 
         void setCurrentElementParser(ElementParser* parser);

--- a/sources/include/parser/gmlfeaturecollectionparser.h
+++ b/sources/include/parser/gmlfeaturecollectionparser.h
@@ -26,6 +26,7 @@ namespace citygml {
 
     private:
         Envelope* m_bounds;
+        bool m_srsSRSOverride;
 
 
     };

--- a/sources/include/parser/gmlfeaturecollectionparser.h
+++ b/sources/include/parser/gmlfeaturecollectionparser.h
@@ -24,9 +24,12 @@ namespace citygml {
         // GMLObjectElementParser interface
         virtual Object* getObject() override;
 
+        const Envelope& getEnvelope() const;
+        bool getSourceSRSOverride() const;
+
     private:
         Envelope* m_bounds;
-        bool m_srsSRSOverride;
+        bool m_sourceSRSOverride;
 
 
     };

--- a/sources/src/parser/citygmldocumentparser.cpp
+++ b/sources/src/parser/citygmldocumentparser.cpp
@@ -30,6 +30,11 @@ namespace citygml {
         return m_rootModel;
     }
 
+    const ParserParams CityGMLDocumentParser::getParserParams() const
+    {
+        return m_parserParams;
+    }
+
     void CityGMLDocumentParser::setCurrentElementParser(ElementParser* parser)
     {
         m_parserStack.push(std::shared_ptr<ElementParser>(parser));

--- a/sources/src/parser/citymodelelementparser.cpp
+++ b/sources/src/parser/citymodelelementparser.cpp
@@ -49,6 +49,12 @@ namespace citygml {
             CITYGML_LOG_WARN(m_logger, "Expected end tag <" << NodeType::CORE_CityModelNode.name() << "> got <" << node.name() << "> at " << getDocumentLocation());
         }
 
+        if (getSourceSRSOverride()) {
+            Envelope *envelope = new Envelope(getEnvelope().srsName());
+            envelope->setLowerBound(m_model->getEnvelope().getLowerBound());
+            envelope->setUpperBound(m_model->getEnvelope().getUpperBound());
+            m_model->setEnvelope(envelope);
+        }
         m_callback(m_model);
         return true;
     }

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -237,6 +237,12 @@ namespace citygml {
 
     bool CityObjectElementParser::parseElementEndTag(const NodeType::XMLNode&, const std::string&)
     {
+        if (getSourceSRSOverride()) {
+            Envelope *envelope = new Envelope(getEnvelope().srsName());
+            envelope->setLowerBound(m_model->getEnvelope().getLowerBound());
+            envelope->setUpperBound(m_model->getEnvelope().getUpperBound());
+            m_model->setEnvelope(envelope);
+        }
         m_callback(m_model);
         m_model = nullptr;
         return true;

--- a/sources/src/parser/gmlfeaturecollectionparser.cpp
+++ b/sources/src/parser/gmlfeaturecollectionparser.cpp
@@ -1,6 +1,7 @@
 #include "parser/gmlfeaturecollectionparser.h"
 
 #include "parser/attributes.h"
+#include "parser/citygmldocumentparser.h"
 #include "parser/parserutils.hpp"
 #include "parser/nodetypes.h"
 
@@ -19,6 +20,12 @@ namespace citygml {
         : GMLObjectElementParser(documentParser, factory, logger)
     {
         m_bounds = nullptr;
+        m_srsSRSOverride = false;
+        std::string paramsSrcSRS = documentParser.getParserParams().srcSRS;
+        if (!paramsSrcSRS.empty()) {
+            m_bounds = new Envelope(paramsSrcSRS);
+            m_srsSRSOverride = true;
+        }
     }
 
     bool GMLFeatureCollectionElementParser::parseChildElementStartTag(const NodeType::XMLNode& node, Attributes& attributes)
@@ -33,6 +40,9 @@ namespace citygml {
             return true;
         } else if (node == NodeType::GML_EnvelopeNode) {
 
+            if (m_srsSRSOverride) {
+                return true;
+            }
             if (m_bounds != nullptr) {
                 CITYGML_LOG_WARN(m_logger, "Duplicate definition of " << NodeType::GML_EnvelopeNode << " at " << getDocumentLocation());
                 return true;

--- a/sources/src/parser/gmlfeaturecollectionparser.cpp
+++ b/sources/src/parser/gmlfeaturecollectionparser.cpp
@@ -20,11 +20,11 @@ namespace citygml {
         : GMLObjectElementParser(documentParser, factory, logger)
     {
         m_bounds = nullptr;
-        m_srsSRSOverride = false;
+        m_sourceSRSOverride = false;
         std::string paramsSrcSRS = documentParser.getParserParams().srcSRS;
         if (!paramsSrcSRS.empty()) {
             m_bounds = new Envelope(paramsSrcSRS);
-            m_srsSRSOverride = true;
+            m_sourceSRSOverride = true;
         }
     }
 
@@ -40,7 +40,7 @@ namespace citygml {
             return true;
         } else if (node == NodeType::GML_EnvelopeNode) {
 
-            if (m_srsSRSOverride) {
+            if (m_sourceSRSOverride) {
                 return true;
             }
             if (m_bounds != nullptr) {
@@ -93,6 +93,14 @@ namespace citygml {
         return getFeatureObject();
     }
 
+    const Envelope& GMLFeatureCollectionElementParser::getEnvelope() const
+    {
+        return *m_bounds;
+    }
 
+    bool GMLFeatureCollectionElementParser::getSourceSRSOverride() const
+    {
+        return m_sourceSRSOverride;
+    }
 
 }

--- a/test/citygmltest.cpp
+++ b/test/citygmltest.cpp
@@ -62,6 +62,7 @@ int main( int argc, char **argv )
         if ( param == "-log" ) { log = true; fargc = i+1; }
         //if ( param == "-filter" ) { if ( i == argc - 1 ) usage(); params.objectsMask = argv[i+1]; i++; fargc = i+1; }
         if ( param == "-destsrs" ) { if ( i == argc - 1 ) usage(); params.destSRS = argv[i+1]; i++; fargc = i+1; }
+        if ( param == "-srcsrs" ) { if ( i == argc - 1 ) usage(); params.srcSRS = argv[i+1]; i++; fargc = i+1; }
     }
 
     if ( argc - fargc < 1 ) usage();


### PR DESCRIPTION
There seems to be open CityGML datasets out there that have good data but do not have an included SRS, even though they are based on one.

The most prominent one of these datasets  is [Montreal](http://donnees.ville.montreal.qc.ca/dataset/maquette-numerique-plateau-mont-royal-batiments-lod2-avec-textures), which has good data including the envelope's upper and lower bounds, but is missing an `srsName` (for Montreal it is EPSG:2950).

This option allows for overriding the SRS information in such data without needing to modify the source CityGML.