### PR TITLE
Read SRS names from geometry tags

### DIFF
--- a/sources/include/citygml/citygmlfactory.h
+++ b/sources/include/citygml/citygmlfactory.h
@@ -34,7 +34,7 @@ namespace citygml {
 
         CityModel* createCityModel(const std::string& id);
         CityObject* createCityObject(const std::string& id, CityObject::CityObjectsType type);
-        Geometry* createGeometry(const std::string& id, const CityObject::CityObjectsType& cityObjType = CityObject::CityObjectsType::COT_All, unsigned int lod = 0);
+        Geometry* createGeometry(const std::string& id, const CityObject::CityObjectsType& cityObjType = CityObject::CityObjectsType::COT_All, unsigned int lod = 0, std::string srsName = "");
 
         std::shared_ptr<Polygon> createPolygon(const std::string& id);
         std::shared_ptr<LineString> createLineString(const std::string& id);

--- a/sources/include/citygml/geometry.h
+++ b/sources/include/citygml/geometry.h
@@ -59,6 +59,10 @@ namespace citygml {
         unsigned int lod() const;
         void setLod(unsigned int lod);
 
+        // Access the srs of the implicit geometry
+        std::string getSRSName() const;
+        void setSRSName(const std::string& srsName);
+
         void addPolygon(std::shared_ptr<Polygon> );
         void addLineString(std::shared_ptr<LineString>);
 
@@ -74,13 +78,15 @@ namespace citygml {
 
 
     protected:
-        Geometry( const std::string& id, GeometryType type = GeometryType::GT_Unknown, unsigned int lod = 0 );
+        Geometry( const std::string& id, GeometryType type = GeometryType::GT_Unknown, unsigned int lod = 0, std::string srsName = "" );
 
         bool m_finished;
 
         GeometryType m_type;
 
         unsigned int m_lod;
+
+        std::string m_srsName;
 
         std::vector<std::shared_ptr<Geometry> > m_childGeometries;
 

--- a/sources/src/citygml/citygmlfactory.cpp
+++ b/sources/src/citygml/citygmlfactory.cpp
@@ -64,9 +64,9 @@ namespace citygml {
 
     }
 
-    Geometry* CityGMLFactory::createGeometry(const std::string& id, const CityObject::CityObjectsType& cityObjType, unsigned int lod)
+    Geometry* CityGMLFactory::createGeometry(const std::string& id, const CityObject::CityObjectsType& cityObjType, unsigned int lod, std::string srsName)
     {
-        Geometry* geom = new Geometry(id, mapCityObjectsTypeToGeometryType(cityObjType), lod);
+        Geometry* geom = new Geometry(id, mapCityObjectsTypeToGeometryType(cityObjType), lod, srsName);
         appearanceTargetCreated(geom);
         return geom;
     }

--- a/sources/src/citygml/geometry.cpp
+++ b/sources/src/citygml/geometry.cpp
@@ -7,8 +7,8 @@
 
 namespace citygml {
 
-    Geometry::Geometry(const std::string& id, Geometry::GeometryType type, unsigned int lod)
-        : AppearanceTarget( id ), m_finished(false), m_type( type ), m_lod( lod )
+    Geometry::Geometry(const std::string& id, Geometry::GeometryType type, unsigned int lod, std::string srsName)
+        : AppearanceTarget( id ), m_finished(false), m_type( type ), m_lod( lod ), m_srsName( srsName )
     {
 
     }
@@ -115,6 +115,15 @@ namespace citygml {
         m_lod = lod;
     }
 
+    std::string Geometry::getSRSName() const
+    {
+        return m_srsName;
+    }
+
+    void Geometry::setSRSName(const std::string& srsName)
+    {
+        m_srsName = srsName;
+    }
 
     void Geometry::addPolygon( std::shared_ptr<Polygon> p )
     {

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -242,6 +242,7 @@ namespace citygml {
 
     void GeoCoordinateTransformer::transform(Geometry& obj, GeoTransform& parentTransformation) {
         GeoTransform transformation = parentTransformation;
+        transformation.setSourceSRS(parentTransformation.sourceURN());
 
         // If geometry has a different SRS or object SRS is not defined
         if (!obj.getSRSName().empty() && !transformation.hasSourceSRS(obj.getSRSName())) {

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -240,7 +240,13 @@ namespace citygml {
         //}
     }
 
-    void GeoCoordinateTransformer::transform(Geometry& obj, GeoTransform& transformation) {
+    void GeoCoordinateTransformer::transform(Geometry& obj, GeoTransform& parentTransformation) {
+        GeoTransform transformation = parentTransformation;
+
+        // If geometry has a different SRS or object SRS is not defined
+        if (!obj.getSRSName().empty() && !transformation.hasSourceSRS(obj.getSRSName())) {
+            transformation.setSourceSRS(obj.getSRSName());
+        }
 
         if (!transformation.valid()) {
             CITYGML_LOG_WARN(m_logger, "No valid spatial reference system is given for Geometry with id '" << obj.getId() << "'. Child Polygons are not transformed"

--- a/sources/src/parser/geometryelementparser.cpp
+++ b/sources/src/parser/geometryelementparser.cpp
@@ -76,7 +76,9 @@ namespace citygml {
             throw std::runtime_error("Unexpected start tag found.");
         }
 
-        m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel);
+        std::string srsName = attributes.getAttribute("srsName");
+
+        m_model = m_factory.createGeometry(attributes.getCityGMLIDAttribute(), m_parentType, m_lodLevel, srsName);
         m_orientation = attributes.getAttribute("orientation", "+"); // A gml:OrientableSurface may define a negative orientation
         return true;
 


### PR DESCRIPTION
Because CityGML is flexible about the SRS, it's possible to have no `CityModel` level envelope with SRS but have SRS at the geometry level.

Turns out, libcitygml was not reading the `srsName` attributes from these tags. This PR fixes that.

The easiest data to test this with is to modify the Berlin file you have in the `data` directory and remove the top level `envelope` tag. Since the file has `srsName` attributes for all `MultiSurface` tags, these will now be stored in the geometry level.

With this change, the data will now we converted into a destination SRS (previously the source SRS would not be found, so nothing would happen).