### PR TITLE
Add missing include for std::function

### DIFF
--- a/sources/include/parser/externalreferenceparser.h
+++ b/sources/include/parser/externalreferenceparser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include "parser/gmlobjectparser.h"
 #include <citygml/externalreference.h>
 

--- a/sources/include/parser/rectifiedgridcoverageparser.h
+++ b/sources/include/parser/rectifiedgridcoverageparser.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <functional>
 #include "parser/gmlfeaturecollectionparser.h"
-
 #include <citygml/rectifiedgridcoverage.h>
 
 


### PR DESCRIPTION
The current version 2.4.0 does not compile for me using GCC 11.1.0. The reason is that in two headers, `std::function` is used without adding the appropriate include for `<functional>`. This MR adds those. Then it compiles fine for me.

Disclaimer: I did not use the new functionality, so I cannot state anything about that functionality. For now, I am only concerned with making it compile and work as it used to.