### PR TITLE
Fix a double-free error with ExternalReference.

### DIFF
--- a/sources/include/citygml/citygmlfactory.h
+++ b/sources/include/citygml/citygmlfactory.h
@@ -41,7 +41,7 @@ namespace citygml {
 
         std::shared_ptr<Polygon> createPolygon(const std::string& id);
         std::shared_ptr<LineString> createLineString(const std::string& id);
-        std::shared_ptr<ExternalReference> createExternalReference(const std::string& id);
+        ExternalReference* createExternalReference(const std::string& id);
 
         /**
          * @brief requests a polygon for a Geometry object that will be added later

--- a/sources/include/parser/externalreferenceparser.h
+++ b/sources/include/parser/externalreferenceparser.h
@@ -25,7 +25,7 @@ namespace citygml {
         virtual Object* getObject() override;
         
     private:
-        std::shared_ptr<ExternalReference> model;
+        std::unique_ptr<ExternalReference> model;
         std::function<void(ExternalReference *)> callback;
     };
 }

--- a/sources/src/citygml/citygmlfactory.cpp
+++ b/sources/src/citygml/citygmlfactory.cpp
@@ -95,10 +95,9 @@ namespace citygml {
         return std::shared_ptr<LineString>(lineString);
     }
 
-    std::shared_ptr<ExternalReference> CityGMLFactory::createExternalReference(const std::string& id)
+    ExternalReference* CityGMLFactory::createExternalReference(const std::string& id)
     {
-        ExternalReference * externalReference = new ExternalReference(id);
-        return std::shared_ptr<ExternalReference>(externalReference);
+        return new ExternalReference(id);
     }
 
     void CityGMLFactory::requestSharedPolygonForGeometry(Geometry* geom, const std::string& polygonId)

--- a/sources/src/parser/externalreferenceparser.cpp
+++ b/sources/src/parser/externalreferenceparser.cpp
@@ -25,13 +25,13 @@ namespace citygml {
             CITYGML_LOG_ERROR(m_logger, "Expected start tag <" << NodeType::CORE_ExternalReferenceNode << "> but got <" << node.name() << "> at " << getDocumentLocation());
         }
         
-        model = m_factory.createExternalReference(attributes.getCityGMLIDAttribute());
+        model.reset(m_factory.createExternalReference(attributes.getCityGMLIDAttribute()));
         
         return true;
     }
 
     bool ExternalReferenceParser::parseElementEndTag(NodeType::XMLNode const& node, std::string const&) {
-        callback(model.get());
+        callback(model.release());
         return true;
     }
 


### PR DESCRIPTION
The `ExternalReferenceParser` created an `ExternalReference` object as a
`std::shared_ptr`. This object is then passed to a callback via a raw
pointer which then passes it to a `CityObject` that saves the raw pointer
inside a `std::unique_ptr`.
The problem with this is that after the parsing is done, the shared_ptr
will go away deleting the `ExternalReference` object. At this point the
unique_ptr in `CityObject` points to a destroyed object. And this will
lead to a crash when the `CityObject` is destroyed and the unique_ptr
tries to delete the already deleted `ExternalReference` object.
To fix this we no longer use a shared_ptr at all but start with a
unique_ptr in the parser that releases its pointer to the callback
thereby giving up its ownership.