### PR TITLE
Fixed some issues caused by dereferencing pointers to elements of an …

### DIFF
--- a/sources/include/citygml/tesselator.h
+++ b/sources/include/citygml/tesselator.h
@@ -57,6 +57,8 @@ public:
     void compute() override;
 
 private:
+    void processContours();
+
     typedef void (APIENTRY *GLU_TESS_CALLBACK)();
     static void CALLBACK beginCallback( GLenum, void* );
     static void CALLBACK vertexDataCallback( GLvoid*, void* );
@@ -65,9 +67,18 @@ private:
     static void CALLBACK errorCallback(GLenum, void*);
 
 private:
+    // 
+    struct ContourRef {
+        ContourRef(unsigned int index, unsigned int length) : index(index), length(length) {}
+        unsigned int index;
+        unsigned int length;
+    };
+
     GLUtesselator *_tobj;
-    GLenum  _curMode;
+    GLenum _curMode;
     GLenum _windingRule;
+    std::vector<TVec3d> _originalVertices;
+    std::vector<ContourRef> _contourQueue;
 };
 
 #endif // __TESSELATOR_H__


### PR DESCRIPTION
Fixed some issues caused by dereferencing pointers to elements of an std::vector that has since been re-allocated.

**Some comments:**
- The `_originalVertices` doesn't have to be a member variable, since we only use it inside the `processContours` function. But it should be more efficient like this, since making it local to the function would cause it to re-allocate every time.
- In `vertexDataCallback`: I replaced the `if (vertex_data[i] != nullptr)` with `if (weight[i] > 0.0f)`, since we're no longer passing pointers but instead index values directly, and an index of 0 would cause the null-check to fail.

#76 