### PR TITLE
Fix -Wreorder / C5038

### DIFF
--- a/sources/include/citygml/citygml.h
+++ b/sources/include/citygml/citygml.h
@@ -67,11 +67,11 @@ namespace citygml
             , minLOD( 0 )
             , maxLOD( 4 )
             , optimize( false )
-            , tesselate( true )
             , pruneEmptyObjects( false )
+            , tesselate( true )
+            , keepVertices ( false )
             , destSRS( "" )
             , srcSRS( "" )
-            , keepVertices ( false )
         { }
 
     public:


### PR DESCRIPTION
Fix -Wreorder C5038: Make sure initialisation order is the same as declaration order.
When using initialisation list, the initialisation order needs to match the declaration order of the variables.

The library fails to build on gcc when using -Wall and -Werror. The same will likely happen on MSVC with equivalent settings.

See this: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5038?view=msvc-170

After this fix, the library builds fine on GCC 11 with -Wall and -Werror flags on.
