### PR TITLE
Parsing fixes

### DIFF
--- a/sources/src/parser/citygmldocumentparser.cpp
+++ b/sources/src/parser/citygmldocumentparser.cpp
@@ -1,4 +1,5 @@
 #include "parser/citygmldocumentparser.h"
+#include "parser/delayedchoiceelementparser.h"
 #include "parser/documentlocation.h"
 #include "parser/nodetypes.h"
 #include "parser/elementparser.h"
@@ -99,6 +100,15 @@ namespace citygml {
 
         m_activeParser = m_parserStack.top();
         CITYGML_LOG_TRACE(m_logger, "Invoke " << m_activeParser->elementParserName() << "::endElement for <" << node << "> at " << getDocumentLocation());
+        
+        if(std::dynamic_pointer_cast<DelayedChoiceElementParser>(m_activeParser) != nullptr) {
+            // We try to close a DelayedChoiceElementParser:
+            // this means no node has been found that contains any of the delayed choice nodes
+            // This is not directly an error: this needs to be treated as an empty node
+            CITYGML_LOG_DEBUG(m_logger, "End tag found while the active parser is a DelayedChoiceElementParser. This probably means the node is empty. The close node is: <" << node << "> at " << getDocumentLocation());
+            removeCurrentElementParser(m_activeParser.get());
+            m_activeParser = m_parserStack.top();
+        }
         if (!m_activeParser->endElement(node, characters)) {
             CITYGML_LOG_ERROR(m_logger, "Active parser " << m_activeParser->elementParserName() << " reports end tag <" << node << "> at " << getDocumentLocation() << " as "
                               << "unknown, but it seems as if the corresponding start tag was not reported as unknown. Please check the parser implementation."

--- a/sources/src/parser/externalreferenceparser.cpp
+++ b/sources/src/parser/externalreferenceparser.cpp
@@ -17,7 +17,7 @@ namespace citygml {
     }
 
     bool ExternalReferenceParser::handlesElement(NodeType::XMLNode const& node) const {
-        return (node.typeID() == NodeType::CORE_ExternalReferenceNode.typeID()|| node.typeID() == NodeType::CORE_InformationSystemNode.typeID());
+        return (node.typeID() == NodeType::CORE_ExternalReferenceNode.typeID() || node.typeID() == NodeType::CORE_InformationSystemNode.typeID());
     }
 
     bool ExternalReferenceParser::parseElementStartTag(NodeType::XMLNode const& node, Attributes & attributes) {

--- a/sources/src/parser/externalreferenceparser.cpp
+++ b/sources/src/parser/externalreferenceparser.cpp
@@ -17,7 +17,7 @@ namespace citygml {
     }
 
     bool ExternalReferenceParser::handlesElement(NodeType::XMLNode const& node) const {
-        return node.typeID() == NodeType::CORE_ExternalReferenceNode.typeID();
+        return (node.typeID() == NodeType::CORE_ExternalReferenceNode.typeID()|| node.typeID() == NodeType::CORE_InformationSystemNode.typeID());
     }
 
     bool ExternalReferenceParser::parseElementStartTag(NodeType::XMLNode const& node, Attributes & attributes) {

--- a/sources/src/parser/parserxercesc.cpp
+++ b/sources/src/parser/parserxercesc.cpp
@@ -65,10 +65,10 @@ std::shared_ptr<XMLCh> toXercesString(const std::string& str) {
 class DocumentLocationXercesAdapter : public citygml::DocumentLocation {
 public:
     explicit DocumentLocationXercesAdapter(const std::string& fileName)
-		: m_locator(nullptr)
-		, m_fileName(fileName)
-	{
-        
+        : m_locator(nullptr)
+        , m_fileName(fileName)
+    {
+
     }
 
     void setLocator(const xercesc::Locator* locator) {
@@ -124,6 +124,8 @@ public:
     // ContentHandler interface
     virtual void startElement(const XMLCh* const, const XMLCh* const, const XMLCh* const qname, const xercesc::Attributes& attrs) override {
         AttributesXercesAdapter attributes(attrs, m_documentLocation, m_logger);
+        // We need to empty m_lastcharacters here, because if a tag is empty, characters(...) will never be called and this variable will contain wrong values
+        m_lastcharacters = "";
         CityGMLDocumentParser::startElement(toStdString(qname), attributes);
     }
 
@@ -133,7 +135,7 @@ public:
     }
 
     virtual void characters(const XMLCh* const chars, const XMLSize_t) override {
-        m_lastcharacters = toStdString(chars);
+        m_lastcharacters += toStdString(chars);
     }
 
     virtual void startDocument() override {
@@ -240,7 +242,7 @@ namespace citygml
             }
 
             stream << " " << message << std::endl;
-        }     
+        }
     };
 
     std::mutex xerces_init_mutex;

--- a/test/citygmltest.cpp
+++ b/test/citygmltest.cpp
@@ -22,6 +22,7 @@
 #include <citygml/citymodel.h>
 #include <citygml/cityobject.h>
 #include <citygml/geometry.h>
+#include <citygml/implictgeometry.h>
 
 #ifdef LIBCITYGML_USE_OPENGL
 #include <citygml/tesselator.h>
@@ -171,6 +172,17 @@ void printGeometry( const citygml::Geometry& geometry, unsigned int indent )
   }
 }
 
+
+void printImplicitGeometry( const citygml::ImplicitGeometry& implicitGeometry, unsigned int indent ) 
+{
+    printIndent(indent);
+    std::cout << "Reference point " << implicitGeometry.getReferencePoint() << std::endl;
+    for ( unsigned int i = 0; i < implicitGeometry.getGeometriesCount(); i++ ) 
+    {
+        printGeometry( implicitGeometry.getGeometry(i), indent+1 );
+    }
+}
+
 void analyzeObject( const citygml::CityObject& object, unsigned int indent )
 {
    printIndent(indent);
@@ -180,6 +192,10 @@ void analyzeObject( const citygml::CityObject& object, unsigned int indent )
    for ( unsigned int i = 0; i < object.getGeometriesCount(); i++ ) 
    {
        printGeometry( object.getGeometry(i), indent+1 );
+   }
+   for ( unsigned int i = 0; i < object.getImplicitGeometryCount(); i++ ) 
+   {
+       printImplicitGeometry( object.getImplicitGeometry(i), indent+1 );
    }
 
    for ( unsigned int i = 0; i < object.getChildCityObjectsCount(); i++ )


### PR DESCRIPTION
Hello,
This PR fixes some problems that I encountered across some files:
* An InformationSystem node inside an ExternalReference node would cause an exception to be thrown. Now, the information system is still not read but the parsing continues.
* Some files contain empty nodes that are instantly closed (\<Node/>). In that case, the m_lastcharacters of the CityGMLHandlerXerces were not cleaned up and could contain unwanted characters.
* I had cases of empty <gml:surfaceMember> nodes. In that case, the parser would fail because DelayedChoiceElementParser::endElement would be called. Now, if we try to call endElement while a DelayedChoiceElementParser is the active parser, we discard it and try to end the parent parser instead