### PR TITLE
dem:TINRelief: Use LOD=0 if dem:lod is not specified

### DIFF
--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -313,7 +313,12 @@ namespace citygml {
                    || node == NodeType::DEM_RidgeOrValleyLinesNode
                    || node == NodeType::DEM_BreaklinesNode) {
             
-            parseGeometryForLODLevel(std::stoi(m_model->getAttribute("dem:lod")));
+            std::string lod = m_model->getAttribute("dem:lod");
+            if (!lod.empty()) {
+                parseGeometryForLODLevel(std::stoi(lod));
+            } else {
+                parseGeometryForLODLevel(0);
+            }
         } else if (node == NodeType::GEN_Lod0TerrainIntersectionNode
                    || node == NodeType::WTR_Lod0MultiCurveNode
                    || node == NodeType::WTR_Lod0MultiSurfaceNode) {


### PR DESCRIPTION
Hi! I'm not 100% sure if you want this PR, but I'll give it a try.

I've run into some gmls where `dem:lod` is missing from TINRelief, although I believe it's required?
These models causes a crash in [cityobjectelementparser.cpp](https://github.com/jklimke/libcitygml/blob/0d52e3a38c11add2a16da058bf92e7aabae43008/sources/src/parser/cityobjectelementparser.cpp#L316).

At least I think it would be nice to avoid the crash, and instead throw a runtime error or something. But handling this (by setting LOD to 0 as I did in this PR) will make terrain from the Berlin 3D dataset work: https://www.businesslocationcenter.de/en/economic-atlas/download-portal

