### PR TITLE
Don't throw runtime error if endElement is called without a bound ele…

### DIFF
--- a/sources/src/parser/citygmlelementparser.cpp
+++ b/sources/src/parser/citygmlelementparser.cpp
@@ -37,8 +37,10 @@ namespace citygml {
             // This might happen if an container element that usally contains a child element links to an exting object using XLink an thus
             // uses a combined start/end element: e.g.: <surfaceMember xlink:href="#..."/>
             // For such elements a child parser must only be created if there is no xlink attribute.
-            CITYGML_LOG_ERROR(m_logger, "CityGMLElementParser::endElement called on unbound " << elementParserName() << " object for element <" << node << "> at " << getDocumentLocation());
-            throw std::runtime_error("CityGMLElementParser::endElement called on unbound CityGMLElementParser object.");
+            // It can also happen in cases when a <cityObjectMember> only contains ignored elements.
+            CITYGML_LOG_WARN(m_logger, "CityGMLElementParser::endElement called on unbound " << elementParserName() << " object for element <" << node << "> at " << getDocumentLocation());
+            m_documentParser.removeCurrentElementParser(this);
+            return true;
         }
 
         if (m_boundElement == node) {


### PR DESCRIPTION
Don't throw runtime error if endElement is called without a bound element, as this is not necessarily a critical issue.

See description/reasoning in issue #92

**TLDR:** endElement being called without a bound element isn't necessarily a critical issue, as it happens when a <cityObjectMember> only contains ignored elements.
And in the case of a container element containing a child element with an xlink, it should still be safe to continue parsing - and instead just print a warning, since this element won't be handled.

This fixes a lot of CityGML datasets I've encountered (see #92 for more info), especially CityGML 3.0 datasets using unimplemented elements.