### PR TITLE
Make structs and unions adhere to C++ standard

### DIFF
--- a/osgplugin/ReaderWriterCityGML.cpp
+++ b/osgplugin/ReaderWriterCityGML.cpp
@@ -177,7 +177,7 @@ public:
 
     virtual ReadResult readNode( const std::string&, const osgDB::ReaderWriter::Options* ) const override;
     virtual ReadResult readNode( std::istream&, const osgDB::ReaderWriter::Options* ) const override;
-  virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const
+    virtual ReadResult readObject(const std::string& fileName, const osgDB::ReaderWriter::Options* options) const override
     {
         ReadResult result = readNode(fileName, options);
         osg::Node* node = result.getNode();
@@ -185,7 +185,7 @@ public:
         else return result;
     }
 
-    virtual ReadResult readObject(std::istream& fin, const Options* options) const
+    virtual ReadResult readObject(std::istream& fin, const Options* options) const override
     {
         ReadResult result = readNode(fin, options);
         osg::Node* node = result.getNode();

--- a/osgplugin/ReaderWriterCityGML.cpp
+++ b/osgplugin/ReaderWriterCityGML.cpp
@@ -526,16 +526,16 @@ void setMaterial(osg::ref_ptr<osg::StateSet> stateset, const citygml::Polygon& p
         return;
     }
 
-    TVec4f diffuse( citygmlMaterial->getDiffuse(), 0.f );
-    TVec4f emissive( citygmlMaterial->getEmissive(), 0.f );
-    TVec4f specular( citygmlMaterial->getSpecular(), 0.f );
+    TVec3f diffuse = citygmlMaterial->getDiffuse();
+    TVec3f emissive = citygmlMaterial->getEmissive();
+    TVec3f specular = citygmlMaterial->getSpecular();
     float ambient = citygmlMaterial->getAmbientIntensity();
 
     osg::Material* material = new osg::Material;
     material->setColorMode( osg::Material::OFF );
-    material->setDiffuse( osg::Material::FRONT_AND_BACK, osg::Vec4(diffuse.r, diffuse.g, diffuse.b, diffuse.a ) );
-    material->setSpecular( osg::Material::FRONT_AND_BACK, osg::Vec4(specular.r, specular.g, specular.b, specular.a ) );
-    material->setEmission( osg::Material::FRONT_AND_BACK, osg::Vec4(emissive.r, emissive.g, emissive.b, emissive.a ) );
+    material->setDiffuse( osg::Material::FRONT_AND_BACK, osg::Vec4(diffuse.x, diffuse.y, diffuse.z, 0.f ) );
+    material->setSpecular( osg::Material::FRONT_AND_BACK, osg::Vec4(specular.x, specular.y, specular.z, 0.f ) );
+    material->setEmission( osg::Material::FRONT_AND_BACK, osg::Vec4(emissive.x, emissive.y, emissive.z, 0.f ) );
     material->setShininess( osg::Material::FRONT_AND_BACK, 128.f * citygmlMaterial->getShininess() );
     material->setAmbient( osg::Material::FRONT_AND_BACK, osg::Vec4( ambient, ambient, ambient, 1.0 ) );
     material->setTransparency( osg::Material::FRONT_AND_BACK, citygmlMaterial->getTransparency() );

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -159,6 +159,7 @@ SET(PUBLIC_HEADER
   include/citygml/address.h
   include/citygml/rectifiedgridcoverage.h
   include/citygml/externalreference.h
+  include/citygml/warnings.h
 )
 
 

--- a/sources/include/citygml/address.h
+++ b/sources/include/citygml/address.h
@@ -2,6 +2,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -26,18 +27,13 @@ namespace citygml {
         void setThoroughfareNumber(const std::string& thoroughfareNumber);
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_country;
         std::string m_locality;
         std::string m_thoroughfareName;
         std::string m_thoroughfareNumber;
         std::string m_postalCode;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 } /* namespace citygml */

--- a/sources/include/citygml/address.h
+++ b/sources/include/citygml/address.h
@@ -26,11 +26,18 @@ namespace citygml {
         void setThoroughfareNumber(const std::string& thoroughfareNumber);
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_country;
         std::string m_locality;
         std::string m_thoroughfareName;
         std::string m_thoroughfareNumber;
         std::string m_postalCode;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 } /* namespace citygml */

--- a/sources/include/citygml/appearance.h
+++ b/sources/include/citygml/appearance.h
@@ -6,6 +6,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 #include <citygml/appearancetarget.h>
 
 namespace citygml {
@@ -15,15 +16,10 @@ namespace citygml {
     class GeoreferencedTexture;
 
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+    PRAGMA_WARN_DLL_BEGIN
     class LIBCITYGML_EXPORT Appearance : public Object, public std::enable_shared_from_this<Appearance>
     {
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+    PRAGMA_WARN_DLL_END
     public:
         std::string getType() const;
 
@@ -49,15 +45,10 @@ namespace citygml {
 
     protected:
         Appearance( const std::string& id, const std::string& typeString );
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_typeString;
         std::vector<std::string> m_themes;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
 
         bool m_isFront;
     };

--- a/sources/include/citygml/appearance.h
+++ b/sources/include/citygml/appearance.h
@@ -14,8 +14,16 @@ namespace citygml {
     class Texture;
     class GeoreferencedTexture;
 
+
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
     class LIBCITYGML_EXPORT Appearance : public Object, public std::enable_shared_from_this<Appearance>
     {
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     public:
         std::string getType() const;
 
@@ -41,8 +49,16 @@ namespace citygml {
 
     protected:
         Appearance( const std::string& id, const std::string& typeString );
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_typeString;
         std::vector<std::string> m_themes;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
+
         bool m_isFront;
     };
 

--- a/sources/include/citygml/appearancemanager.h
+++ b/sources/include/citygml/appearancemanager.h
@@ -53,12 +53,19 @@ namespace citygml {
 
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::unordered_map<std::string, std::shared_ptr<Appearance> > m_appearancesMap;
         std::vector<std::shared_ptr<MaterialTargetDefinition> > m_materialTargetDefinitions;
         std::vector<std::shared_ptr<TextureTargetDefinition> > m_texTargetDefinitions;
         std::unordered_set<std::string> m_themes;
         std::unordered_map<std::string, AppearanceTarget*> m_appearanceTargetsMap;
         std::shared_ptr<CityGMLLogger> m_logger;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
 
         void addThemesFrom(std::shared_ptr<Appearance> surfaceData);
     };

--- a/sources/include/citygml/appearancemanager.h
+++ b/sources/include/citygml/appearancemanager.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 
 namespace citygml {
@@ -53,19 +54,14 @@ namespace citygml {
 
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::unordered_map<std::string, std::shared_ptr<Appearance> > m_appearancesMap;
         std::vector<std::shared_ptr<MaterialTargetDefinition> > m_materialTargetDefinitions;
         std::vector<std::shared_ptr<TextureTargetDefinition> > m_texTargetDefinitions;
         std::unordered_set<std::string> m_themes;
         std::unordered_map<std::string, AppearanceTarget*> m_appearanceTargetsMap;
         std::shared_ptr<CityGMLLogger> m_logger;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
 
         void addThemesFrom(std::shared_ptr<Appearance> surfaceData);
     };

--- a/sources/include/citygml/appearancetarget.h
+++ b/sources/include/citygml/appearancetarget.h
@@ -45,11 +45,18 @@ namespace citygml {
 
 
     private:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::unordered_map<std::string, std::shared_ptr<MaterialTargetDefinition> > m_themeMatMapFront;
         std::unordered_map<std::string, std::shared_ptr<MaterialTargetDefinition> > m_themeMatMapBack;
 
         std::unordered_map<std::string, std::shared_ptr<TextureTargetDefinition> > m_themeTexMapFront;
         std::unordered_map<std::string, std::shared_ptr<TextureTargetDefinition> > m_themeTexMapBack;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
 
     };
 }

--- a/sources/include/citygml/appearancetarget.h
+++ b/sources/include/citygml/appearancetarget.h
@@ -6,6 +6,7 @@
 
 #include <citygml/object.h>
 #include <citygml/appearancetargetdefinition.h>
+#include <citygml/warnings.h>
 
 
 namespace citygml {
@@ -45,18 +46,13 @@ namespace citygml {
 
 
     private:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::unordered_map<std::string, std::shared_ptr<MaterialTargetDefinition> > m_themeMatMapFront;
         std::unordered_map<std::string, std::shared_ptr<MaterialTargetDefinition> > m_themeMatMapBack;
 
         std::unordered_map<std::string, std::shared_ptr<TextureTargetDefinition> > m_themeTexMapFront;
         std::unordered_map<std::string, std::shared_ptr<TextureTargetDefinition> > m_themeTexMapBack;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
 
     };
 }

--- a/sources/include/citygml/appearancetargetdefinition.h
+++ b/sources/include/citygml/appearancetargetdefinition.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -39,15 +40,10 @@ namespace citygml {
         virtual ~AppearanceTargetDefinition() {}
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_targetID;
         std::shared_ptr<T> m_appearance;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
 
     };
 

--- a/sources/include/citygml/appearancetargetdefinition.h
+++ b/sources/include/citygml/appearancetargetdefinition.h
@@ -39,8 +39,16 @@ namespace citygml {
         virtual ~AppearanceTargetDefinition() {}
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_targetID;
         std::shared_ptr<T> m_appearance;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
+
     };
 
 }

--- a/sources/include/citygml/attributesmap.h
+++ b/sources/include/citygml/attributesmap.h
@@ -45,7 +45,14 @@ public:
     int asInteger(int defaultValue=0) const;
 private:
     AttributeType m_type;
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
     std::string m_value;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
 };
 
 LIBCITYGML_EXPORT std::ostream& operator<<(std::ostream& os, const AttributeValue& o);

--- a/sources/include/citygml/attributesmap.h
+++ b/sources/include/citygml/attributesmap.h
@@ -4,6 +4,7 @@
 #include <map>
 
 #include <citygml/citygml_api.h>
+#include <citygml/warnings.h>
 
 namespace citygml
 {
@@ -45,14 +46,9 @@ public:
     int asInteger(int defaultValue=0) const;
 private:
     AttributeType m_type;
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+    PRAGMA_WARN_DLL_BEGIN
     std::string m_value;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+    PRAGMA_WARN_DLL_END
 };
 
 LIBCITYGML_EXPORT std::ostream& operator<<(std::ostream& os, const AttributeValue& o);

--- a/sources/include/citygml/citygml.h
+++ b/sources/include/citygml/citygml.h
@@ -82,8 +82,15 @@ namespace citygml
         bool pruneEmptyObjects;
         bool tesselate;
         bool keepVertices;
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string destSRS;
         std::string srcSRS;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::shared_ptr<const CityModel> load( std::istream& stream, const ParserParams& params, std::unique_ptr<TesselatorBase> tesselator, std::shared_ptr<CityGMLLogger> logger = nullptr);

--- a/sources/include/citygml/citygml.h
+++ b/sources/include/citygml/citygml.h
@@ -32,6 +32,7 @@
 #include <citygml/cityobject.h>
 #include <citygml/envelope.h>
 #include <citygml/tesselatorbase.h>
+#include <citygml/warnings.h>
 
 namespace citygml
 {
@@ -82,15 +83,10 @@ namespace citygml
         bool pruneEmptyObjects;
         bool tesselate;
         bool keepVertices;
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string destSRS;
         std::string srcSRS;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::shared_ptr<const CityModel> load( std::istream& stream, const ParserParams& params, std::unique_ptr<TesselatorBase> tesselator, std::shared_ptr<CityGMLLogger> logger = nullptr);

--- a/sources/include/citygml/citygmlfactory.h
+++ b/sources/include/citygml/citygmlfactory.h
@@ -70,10 +70,17 @@ namespace citygml {
     protected:
         void appearanceTargetCreated(AppearanceTarget* obj);
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::shared_ptr<CityGMLLogger> m_logger;
         std::unique_ptr<AppearanceManager> m_appearanceManager;
         std::unique_ptr<PolygonManager> m_polygonManager;
         std::unique_ptr<GeometryManager> m_geometryManager;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/citygmlfactory.h
+++ b/sources/include/citygml/citygmlfactory.h
@@ -3,6 +3,7 @@
 #include <citygml/geometry.h>
 #include <citygml/cityobject.h>
 #include <citygml/externalreference.h>
+#include <citygml/warnings.h>
 
 #include <memory>
 
@@ -70,17 +71,12 @@ namespace citygml {
     protected:
         void appearanceTargetCreated(AppearanceTarget* obj);
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::shared_ptr<CityGMLLogger> m_logger;
         std::unique_ptr<AppearanceManager> m_appearanceManager;
         std::unique_ptr<PolygonManager> m_polygonManager;
         std::unique_ptr<GeometryManager> m_geometryManager;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/citymodel.h
+++ b/sources/include/citygml/citymodel.h
@@ -54,6 +54,11 @@ namespace citygml {
 
         void addToCityObjectsMapRecursive(const CityObject* cityObj);
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
+
         CityObjects m_roots;
 
         CityObjectsMap m_cityObjectsMap;
@@ -61,6 +66,10 @@ namespace citygml {
         std::string m_srsName;
 
         std::vector<std::string> m_themes;
+
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::CityModel & );

--- a/sources/include/citygml/citymodel.h
+++ b/sources/include/citygml/citymodel.h
@@ -7,6 +7,7 @@
 #include <citygml/citygml_api.h>
 #include <citygml/cityobject.h>
 #include <citygml/featureobject.h>
+#include <citygml/warnings.h>
 
 class TesselatorBase;
 
@@ -54,11 +55,7 @@ namespace citygml {
 
         void addToCityObjectsMapRecursive(const CityObject* cityObj);
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
-
+        PRAGMA_WARN_DLL_BEGIN
         CityObjects m_roots;
 
         CityObjectsMap m_cityObjectsMap;
@@ -66,10 +63,7 @@ namespace citygml {
         std::string m_srsName;
 
         std::vector<std::string> m_themes;
-
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::CityModel & );

--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -8,6 +8,7 @@
 #include <citygml/enum_type_bitmask.h>
 #include <citygml/rectifiedgridcoverage.h>
 #include <citygml/externalreference.h>
+#include <citygml/warnings.h>
 class TesselatorBase;
 
 namespace citygml {
@@ -141,19 +142,14 @@ namespace citygml {
     protected:
         CityObjectsType m_type;
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::vector<std::unique_ptr<Geometry> > m_geometries;
         std::vector<std::unique_ptr<ImplicitGeometry> > m_implicitGeometries;
         std::vector<std::unique_ptr<CityObject> > m_children;
         std::unique_ptr<Address> m_address;
         std::unique_ptr<RectifiedGridCoverage> m_rectifiedGridCoverage;
         std::unique_ptr<ExternalReference> m_externalReference;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream& os, const CityObject& o );

--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -141,12 +141,19 @@ namespace citygml {
     protected:
         CityObjectsType m_type;
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::vector<std::unique_ptr<Geometry> > m_geometries;
         std::vector<std::unique_ptr<ImplicitGeometry> > m_implicitGeometries;
         std::vector<std::unique_ptr<CityObject> > m_children;
         std::unique_ptr<Address> m_address;
         std::unique_ptr<RectifiedGridCoverage> m_rectifiedGridCoverage;
         std::unique_ptr<ExternalReference> m_externalReference;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream& os, const CityObject& o );

--- a/sources/include/citygml/envelope.h
+++ b/sources/include/citygml/envelope.h
@@ -36,9 +36,16 @@ namespace citygml {
         const bool validBounds() const;
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         TVec3d m_lowerBound;
         TVec3d m_upperBound;
         std::string m_srsName;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::Envelope& );

--- a/sources/include/citygml/envelope.h
+++ b/sources/include/citygml/envelope.h
@@ -4,6 +4,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/vecs.hpp>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -36,16 +37,11 @@ namespace citygml {
         const bool validBounds() const;
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         TVec3d m_lowerBound;
         TVec3d m_upperBound;
         std::string m_srsName;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::Envelope& );

--- a/sources/include/citygml/externalreference.h
+++ b/sources/include/citygml/externalreference.h
@@ -5,8 +5,15 @@
 
 namespace citygml {
     union LIBCITYGML_EXPORT ExternalObjectReference {
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string name;
         std::string uri;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
         
         ExternalObjectReference();
         ~ExternalObjectReference();
@@ -19,7 +26,14 @@ namespace citygml {
         ExternalReference(std::string const& id);
 //        ~ExternalReference() noexcept override;                    // Destructor
     public:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string informationSystem;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
         ExternalObjectReference externalObject;
     };
 }

--- a/sources/include/citygml/externalreference.h
+++ b/sources/include/citygml/externalreference.h
@@ -1,19 +1,15 @@
 #pragma once
 
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 
 
 namespace citygml {
     union LIBCITYGML_EXPORT ExternalObjectReference {
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string name;
         std::string uri;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
         
         ExternalObjectReference();
         ~ExternalObjectReference();
@@ -26,14 +22,9 @@ namespace citygml {
         ExternalReference(std::string const& id);
 //        ~ExternalReference() noexcept override;                    // Destructor
     public:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string informationSystem;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
         ExternalObjectReference externalObject;
     };
 }

--- a/sources/include/citygml/externalreference.h
+++ b/sources/include/citygml/externalreference.h
@@ -5,14 +5,23 @@
 
 
 namespace citygml {
-    union LIBCITYGML_EXPORT ExternalObjectReference {
+    class LIBCITYGML_EXPORT ExternalObjectReference {
+    public:
+        ExternalObjectReference() = default;
+        ~ExternalObjectReference() = default;
+
+        const std::string& getName() const;
+        const std::string& getUri() const;
+        void setName(const std::string& name);
+        void setUri(const std::string& uri);
+
+    private:
         PRAGMA_WARN_DLL_BEGIN
-        std::string name;
-        std::string uri;
+        std::string value;
         PRAGMA_WARN_DLL_END
-        
-        ExternalObjectReference();
-        ~ExternalObjectReference();
+
+        enum class ObjectRefType { NAME, URI };
+        ObjectRefType type;
     };
 
     class LIBCITYGML_EXPORT ExternalReference: public Object {

--- a/sources/include/citygml/featureobject.h
+++ b/sources/include/citygml/featureobject.h
@@ -19,7 +19,14 @@ namespace citygml {
         virtual ~FeatureObject();
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::unique_ptr<Envelope> m_envelope;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/featureobject.h
+++ b/sources/include/citygml/featureobject.h
@@ -4,6 +4,7 @@
 
 #include <citygml/object.h>
 #include <citygml/envelope.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -19,14 +20,9 @@ namespace citygml {
         virtual ~FeatureObject();
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::unique_ptr<Envelope> m_envelope;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/geometry.h
+++ b/sources/include/citygml/geometry.h
@@ -87,12 +87,19 @@ namespace citygml {
 
         unsigned int m_lod;
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_srsName;
 
         std::vector<std::shared_ptr<Geometry> > m_childGeometries;
 
         std::vector<std::shared_ptr<Polygon> > m_polygons;
         std::vector<std::shared_ptr<LineString> > m_lineStrings;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream& os, const citygml::Geometry& s );

--- a/sources/include/citygml/geometry.h
+++ b/sources/include/citygml/geometry.h
@@ -6,6 +6,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/appearancetarget.h>
+#include <citygml/warnings.h>
 
 class TesselatorBase;
 
@@ -87,19 +88,14 @@ namespace citygml {
 
         unsigned int m_lod;
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_srsName;
 
         std::vector<std::shared_ptr<Geometry> > m_childGeometries;
 
         std::vector<std::shared_ptr<Polygon> > m_polygons;
         std::vector<std::shared_ptr<LineString> > m_lineStrings;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream& os, const citygml::Geometry& s );

--- a/sources/include/citygml/geometrymanager.h
+++ b/sources/include/citygml/geometrymanager.h
@@ -36,9 +36,16 @@ namespace citygml {
             std::string geometryID;
         };
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::shared_ptr<CityGMLLogger> m_logger;
         std::vector<GeometryRequest> m_geometryRequests;
         std::unordered_map<std::string, std::shared_ptr<Geometry> > m_sharedGeometries;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/geometrymanager.h
+++ b/sources/include/citygml/geometrymanager.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <citygml/citygml_api.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -36,16 +37,11 @@ namespace citygml {
             std::string geometryID;
         };
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::shared_ptr<CityGMLLogger> m_logger;
         std::vector<GeometryRequest> m_geometryRequests;
         std::unordered_map<std::string, std::shared_ptr<Geometry> > m_sharedGeometries;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/implictgeometry.h
+++ b/sources/include/citygml/implictgeometry.h
@@ -5,6 +5,7 @@
 
 #include <citygml/object.h>
 #include <citygml/transformmatrix.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 
 namespace citygml {
@@ -38,15 +39,10 @@ namespace citygml {
         ImplicitGeometry(const std::string& id);
 
         TransformationMatrix     m_matrix;
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         TVec3d                   m_referencePoint;
         std::vector<std::shared_ptr<Geometry> >   m_geometries;
         std::string              m_srsName;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 }

--- a/sources/include/citygml/implictgeometry.h
+++ b/sources/include/citygml/implictgeometry.h
@@ -38,8 +38,15 @@ namespace citygml {
         ImplicitGeometry(const std::string& id);
 
         TransformationMatrix     m_matrix;
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         TVec3d                   m_referencePoint;
         std::vector<std::shared_ptr<Geometry> >   m_geometries;
         std::string              m_srsName;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 }

--- a/sources/include/citygml/linearring.h
+++ b/sources/include/citygml/linearring.h
@@ -36,7 +36,14 @@ namespace citygml {
     protected:
         bool m_exterior;
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::vector<TVec3d> m_vertices;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/linearring.h
+++ b/sources/include/citygml/linearring.h
@@ -5,6 +5,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 
 namespace citygml {
@@ -36,14 +37,9 @@ namespace citygml {
     protected:
         bool m_exterior;
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::vector<TVec3d> m_vertices;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/linestring.h
+++ b/sources/include/citygml/linestring.h
@@ -32,8 +32,15 @@ namespace citygml {
 
     protected:
         LineString(const std::string& id);
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::vector<TVec2d> m_vertices_2d;
         std::vector<TVec3d> m_vertices_3d;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
         int m_dimensions;
     };
 

--- a/sources/include/citygml/linestring.h
+++ b/sources/include/citygml/linestring.h
@@ -2,6 +2,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/object.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 #include <memory>
 
@@ -32,15 +33,10 @@ namespace citygml {
 
     protected:
         LineString(const std::string& id);
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::vector<TVec2d> m_vertices_2d;
         std::vector<TVec3d> m_vertices_3d;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
         int m_dimensions;
     };
 

--- a/sources/include/citygml/material.h
+++ b/sources/include/citygml/material.h
@@ -45,9 +45,16 @@ namespace citygml {
 
     protected:
         Material( const std::string& id );
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         TVec3f m_diffuse;
         TVec3f m_emissive;
         TVec3f m_specular;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
         float m_ambientIntensity;
         float m_shininess;
         float m_transparency;

--- a/sources/include/citygml/material.h
+++ b/sources/include/citygml/material.h
@@ -2,6 +2,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/appearance.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 #include <unordered_set>
 
@@ -45,16 +46,11 @@ namespace citygml {
 
     protected:
         Material( const std::string& id );
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         TVec3f m_diffuse;
         TVec3f m_emissive;
         TVec3f m_specular;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
         float m_ambientIntensity;
         float m_shininess;
         float m_transparency;

--- a/sources/include/citygml/object.h
+++ b/sources/include/citygml/object.h
@@ -28,9 +28,16 @@ namespace citygml {
 
     protected:
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_id;
 
         AttributesMap m_attributes;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::Object& );

--- a/sources/include/citygml/object.h
+++ b/sources/include/citygml/object.h
@@ -4,6 +4,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/attributesmap.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
     /**
@@ -28,16 +29,11 @@ namespace citygml {
 
     protected:
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_id;
 
         AttributesMap m_attributes;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
     LIBCITYGML_EXPORT std::ostream& operator<<( std::ostream&, const citygml::Object& );

--- a/sources/include/citygml/polygon.h
+++ b/sources/include/citygml/polygon.h
@@ -10,6 +10,7 @@
 #include <citygml/vecs.hpp>
 #include <citygml/linearring.h>
 #include <citygml/geometry.h>
+#include <citygml/warnings.h>
 
 class TesselatorBase;
 
@@ -121,10 +122,7 @@ namespace citygml {
 
         TVec3d computeNormal();
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::vector<TVec3d> m_vertices;
         std::unordered_map<std::string, std::vector<TVec2f> > m_themeToFrontTexCoordsMap;
         std::unordered_map<std::string, std::vector<TVec2f> > m_themeToBackTexCoordsMap;
@@ -132,20 +130,13 @@ namespace citygml {
 
         std::shared_ptr<LinearRing> m_exteriorRing;
         std::vector<std::shared_ptr<LinearRing> > m_interiorRings;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
 
         bool m_negNormal;
         bool m_finished;
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::shared_ptr<CityGMLLogger> m_logger;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 }

--- a/sources/include/citygml/polygon.h
+++ b/sources/include/citygml/polygon.h
@@ -121,6 +121,10 @@ namespace citygml {
 
         TVec3d computeNormal();
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::vector<TVec3d> m_vertices;
         std::unordered_map<std::string, std::vector<TVec2f> > m_themeToFrontTexCoordsMap;
         std::unordered_map<std::string, std::vector<TVec2f> > m_themeToBackTexCoordsMap;
@@ -128,10 +132,20 @@ namespace citygml {
 
         std::shared_ptr<LinearRing> m_exteriorRing;
         std::vector<std::shared_ptr<LinearRing> > m_interiorRings;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
 
         bool m_negNormal;
         bool m_finished;
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::shared_ptr<CityGMLLogger> m_logger;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 }

--- a/sources/include/citygml/polygonmanager.h
+++ b/sources/include/citygml/polygonmanager.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <citygml/citygml_api.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -36,16 +37,11 @@ namespace citygml {
             std::string polygonID;
         };
 
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::shared_ptr<CityGMLLogger> m_logger;
         std::vector<PolygonRequest> m_polygonRequests;
         std::unordered_map<std::string, std::shared_ptr<Polygon> > m_sharedPolygons;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/polygonmanager.h
+++ b/sources/include/citygml/polygonmanager.h
@@ -36,9 +36,16 @@ namespace citygml {
             std::string polygonID;
         };
 
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::shared_ptr<CityGMLLogger> m_logger;
         std::vector<PolygonRequest> m_polygonRequests;
         std::unordered_map<std::string, std::shared_ptr<Polygon> > m_sharedPolygons;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/tesselator.h
+++ b/sources/include/citygml/tesselator.h
@@ -77,8 +77,16 @@ private:
     GLUtesselator *_tobj;
     GLenum _curMode;
     GLenum _windingRule;
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
     std::vector<TVec3d> _originalVertices;
     std::vector<ContourRef> _contourQueue;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
+
 };
 
 #endif // __TESSELATOR_H__

--- a/sources/include/citygml/tesselator.h
+++ b/sources/include/citygml/tesselator.h
@@ -33,6 +33,7 @@
 #include <citygml/citygml_api.h>
 #include <citygml/tesselatorbase.h>
 #include <citygml/vecs.hpp>
+#include <citygml/warnings.h>
 
 namespace citygml {
     class CityGMLLogger;
@@ -77,15 +78,10 @@ private:
     GLUtesselator *_tobj;
     GLenum _curMode;
     GLenum _windingRule;
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+    PRAGMA_WARN_DLL_BEGIN
     std::vector<TVec3d> _originalVertices;
     std::vector<ContourRef> _contourQueue;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+    PRAGMA_WARN_DLL_END
 
 };
 

--- a/sources/include/citygml/tesselatorbase.h
+++ b/sources/include/citygml/tesselatorbase.h
@@ -19,6 +19,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/vecs.hpp>
+#include <citygml/warnings.h>
 #include <vector>
 #include <memory>
 
@@ -55,10 +56,7 @@ public:
     bool keepVertices() const;
 
 protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+    PRAGMA_WARN_DLL_BEGIN
     std::vector<TVec3d> _vertices;
     std::vector<std::vector<TVec2f> > _texCoordsLists;
     std::vector<unsigned int> _indices;
@@ -66,9 +64,7 @@ protected:
 
     std::vector<unsigned int> _curIndices;
     std::shared_ptr<citygml::CityGMLLogger> _logger;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+    PRAGMA_WARN_DLL_END
 
     bool _keepVertices;
 };

--- a/sources/include/citygml/tesselatorbase.h
+++ b/sources/include/citygml/tesselatorbase.h
@@ -55,6 +55,10 @@ public:
     bool keepVertices() const;
 
 protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
     std::vector<TVec3d> _vertices;
     std::vector<std::vector<TVec2f> > _texCoordsLists;
     std::vector<unsigned int> _indices;
@@ -62,6 +66,9 @@ protected:
 
     std::vector<unsigned int> _curIndices;
     std::shared_ptr<citygml::CityGMLLogger> _logger;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
 
     bool _keepVertices;
 };

--- a/sources/include/citygml/texture.h
+++ b/sources/include/citygml/texture.h
@@ -4,6 +4,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/appearance.h>
+#include <citygml/warnings.h>
 #include <citygml/vecs.hpp>
 
 namespace citygml {
@@ -52,24 +53,14 @@ namespace citygml {
     protected:
         Texture( const std::string& id );
         Texture( const std::string& id, const std::string& type );
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_url;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
         bool m_repeat;
         WrapMode m_wrapMode;
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         TVec4f m_borderColor;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 
 }

--- a/sources/include/citygml/texture.h
+++ b/sources/include/citygml/texture.h
@@ -52,10 +52,24 @@ namespace citygml {
     protected:
         Texture( const std::string& id );
         Texture( const std::string& id, const std::string& type );
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_url;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
         bool m_repeat;
         WrapMode m_wrapMode;
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         TVec4f m_borderColor;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 
 }

--- a/sources/include/citygml/texturecoordinates.h
+++ b/sources/include/citygml/texturecoordinates.h
@@ -6,6 +6,7 @@
 
 #include <citygml/citygml_api.h>
 #include <citygml/vecs.hpp>
+#include <citygml/warnings.h>
 #include <citygml/object.h>
 
 namespace citygml {
@@ -28,14 +29,9 @@ namespace citygml {
         bool eraseCoordinate(unsigned int i);
 
     protected:
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::string m_targetID;
         std::vector<TVec2f> m_coordlist;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 }

--- a/sources/include/citygml/texturecoordinates.h
+++ b/sources/include/citygml/texturecoordinates.h
@@ -28,7 +28,14 @@ namespace citygml {
         bool eraseCoordinate(unsigned int i);
 
     protected:
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::string m_targetID;
         std::vector<TVec2f> m_coordlist;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 }

--- a/sources/include/citygml/texturetargetdefinition.h
+++ b/sources/include/citygml/texturetargetdefinition.h
@@ -6,6 +6,7 @@
 #include <citygml/citygml_api.h>
 #include <citygml/appearancetargetdefinition.h>
 #include <citygml/texture.h>
+#include <citygml/warnings.h>
 
 namespace citygml {
 
@@ -46,14 +47,9 @@ namespace citygml {
 
     protected:
         TextureTargetDefinition(const std::string& targetID, std::shared_ptr<Texture> appearance, const std::string& id);
-#ifdef _MSC_VER
-#	pragma warning(push)
-#	pragma warning(disable : 4251 4275)
-#endif
+        PRAGMA_WARN_DLL_BEGIN
         std::vector<std::shared_ptr<TextureCoordinates> > m_coordinatesList;
         std::unordered_map<std::string, std::shared_ptr<TextureCoordinates> > m_idTexCoordMap;
-#ifdef _MSC_VER
-#	pragma warning(pop)
-#endif
+        PRAGMA_WARN_DLL_END
     };
 }

--- a/sources/include/citygml/texturetargetdefinition.h
+++ b/sources/include/citygml/texturetargetdefinition.h
@@ -46,7 +46,14 @@ namespace citygml {
 
     protected:
         TextureTargetDefinition(const std::string& targetID, std::shared_ptr<Texture> appearance, const std::string& id);
+#ifdef _MSC_VER
+#	pragma warning(push)
+#	pragma warning(disable : 4251 4275)
+#endif
         std::vector<std::shared_ptr<TextureCoordinates> > m_coordinatesList;
         std::unordered_map<std::string, std::shared_ptr<TextureCoordinates> > m_idTexCoordMap;
+#ifdef _MSC_VER
+#	pragma warning(pop)
+#endif
     };
 }

--- a/sources/include/citygml/vecs.hpp
+++ b/sources/include/citygml/vecs.hpp
@@ -114,17 +114,10 @@ typedef TVec2< double >			TVec2d;
 template< class T > class TVec3
 {
 public:
-    union
-    {
-        T xyz[3];
-        T rgb[3];
-        struct { T x, y, z; };
-        struct { T r, g, b; };
-    };
+    T x, y, z;
 
 public:
     TVec3( const T x = (T)0, const T y = (T)0, const T z = (T)0 );
-    TVec3( const T vec[] );
 
     inline T length() const;
     inline T sqrLength() const;
@@ -148,9 +141,6 @@ public:
 
     inline bool operator==( const TVec3<T>& rhs ) const;
     inline bool operator!=( const TVec3<T>& rhs ) const;
-
-    inline operator T*() { return xyz; }
-    inline operator const T*() const { return xyz; }
 };
 
 template< class T > inline TVec3<T>::TVec3( const T x, const T y, const T z )
@@ -158,11 +148,6 @@ template< class T > inline TVec3<T>::TVec3( const T x, const T y, const T z )
     this->x = x;
     this->y = y;
     this->z = z;
-}
-
-template< class T >	inline TVec3<T>::TVec3( const T vec[] )
-{
-    memcpy( xyz, vec, 3 * sizeof(T) );
 }
 
 template< class T > inline T TVec3<T>::length() const
@@ -301,13 +286,7 @@ typedef TVec3< double >			TVec3d;
 template< class T > class TVec4
 {
 public:
-    union
-    {
-        T xyzw[4];
-        T rgba[4];
-        struct { T x, y, z, w; };
-        struct { T r, g, b, a; };
-    };
+    T x, y, z, w;
 
 public:
     TVec4( const T x = (T)0, const T y = (T)0, const T z = (T)0, const T w = (T)0 )
@@ -317,10 +296,6 @@ public:
         this->z = z;
         this->w = w;
     }
-
-    TVec4( const T vec[], const T w ) { memcpy( xyzw, vec, 4 * sizeof(T) ); this->w = w; }
-
-    TVec4( const T vec[] ) { memcpy( xyzw, vec, 4 * sizeof(T) ); }
 };
 
 template<class T> inline std::ostream& operator<<( std::ostream & os, TVec4<T> const & v )

--- a/sources/include/citygml/warnings.h
+++ b/sources/include/citygml/warnings.h
@@ -1,0 +1,26 @@
+/* -*-c++-*- libcitygml - Copyright (c) 2010 Joachim Pouderoux, BRGM
+*
+* This file is part of libcitygml library
+* http://code.google.com/p/libcitygml
+*
+* libcitygml is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 2.1 of the License, or
+* (at your option) any later version.
+*
+* libcitygml is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*/
+
+#pragma once
+
+#ifdef _MSC_VER
+#define PRAGMA_WARN_DLL_BEGIN _Pragma("warning(push)") \
+_Pragma("warning(disable : 4251 4275)")
+#define PRAGMA_WARN_DLL_END _Pragma("warning(pop)")
+#else
+#define PRAGMA_WARN_DLL_BEGIN
+#define PRAGMA_WARN_DLL_END
+#endif

--- a/sources/src/citygml/citymodel.cpp
+++ b/sources/src/citygml/citymodel.cpp
@@ -96,7 +96,7 @@ namespace citygml
 
     unsigned int CityModel::getNumRootCityObjects() const
     {
-        return m_roots.size();
+        return static_cast<unsigned int>(m_roots.size());
     }
 
     CityObject& CityModel::getRootCityObject(int i)

--- a/sources/src/citygml/citymodel.cpp
+++ b/sources/src/citygml/citymodel.cpp
@@ -55,7 +55,7 @@ namespace citygml
             it->second.push_back(cityObj);
         }
 
-        for (int i = 0; i < cityObj->getChildCityObjectsCount(); i++) {
+        for (unsigned int i = 0; i < cityObj->getChildCityObjectsCount(); i++) {
             addToCityObjectsMapRecursive(&cityObj->getChildCityObject(i));
         }
     }

--- a/sources/src/citygml/cityobject.cpp
+++ b/sources/src/citygml/cityobject.cpp
@@ -125,7 +125,7 @@ namespace citygml {
         }
 
         for (std::unique_ptr<ImplicitGeometry>& implictGeom : m_implicitGeometries) {
-            for (int i = 0; i < implictGeom->getGeometriesCount(); i++) {
+            for (unsigned int i = 0; i < implictGeom->getGeometriesCount(); i++) {
                 implictGeom->getGeometry(i).finish(tesselator, optimize, logger);
             }
         }

--- a/sources/src/citygml/cityobject.cpp
+++ b/sources/src/citygml/cityobject.cpp
@@ -30,7 +30,7 @@ namespace citygml {
 
     unsigned int CityObject::getGeometriesCount() const
     {
-        return m_geometries.size();
+        return static_cast<unsigned int>(m_geometries.size());
     }
 
     const Geometry& CityObject::getGeometry(unsigned int i) const
@@ -50,7 +50,7 @@ namespace citygml {
 
     unsigned int CityObject::getImplicitGeometryCount() const
     {
-        return m_implicitGeometries.size();
+        return static_cast<unsigned int>(m_implicitGeometries.size());
     }
 
     const ImplicitGeometry& CityObject::getImplicitGeometry(unsigned int i) const
@@ -70,7 +70,7 @@ namespace citygml {
 
     unsigned int CityObject::getChildCityObjectsCount() const
     {
-        return m_children.size();
+        return static_cast<unsigned int>(m_children.size());
     }
 
     const CityObject& CityObject::getChildCityObject(unsigned int i) const

--- a/sources/src/citygml/envelope.cpp
+++ b/sources/src/citygml/envelope.cpp
@@ -54,8 +54,8 @@ namespace citygml {
 
     const bool Envelope::validBounds() const
     {
-        return !(ISNAN(m_lowerBound[0]) ||  ISNAN(m_lowerBound[1]) || ISNAN(m_lowerBound[2])
-                || ISNAN(m_upperBound[0]) ||  ISNAN(m_upperBound[1]) || ISNAN(m_upperBound[2]));
+        return !(ISNAN(m_lowerBound.x) ||  ISNAN(m_lowerBound.y) || ISNAN(m_lowerBound.z)
+                || ISNAN(m_upperBound.x) ||  ISNAN(m_upperBound.y) || ISNAN(m_upperBound.z));
     }
 
     std::ostream& operator<<( std::ostream& os, const Envelope& e )

--- a/sources/src/citygml/externalreference.cpp
+++ b/sources/src/citygml/externalreference.cpp
@@ -1,10 +1,34 @@
 #include <citygml/externalreference.h>
 
 namespace citygml {
-    ExternalObjectReference::ExternalObjectReference() {
+    namespace {
+        const std::string EMPTY_STRING("");
+    } // anonymous namespace
+
+    const std::string& ExternalObjectReference::getName() const {
+        if (type == ObjectRefType::NAME) {
+            return value;
+        } else {
+            return EMPTY_STRING;
+        }
     }
 
-    ExternalObjectReference::~ExternalObjectReference() {
+    const std::string& ExternalObjectReference::getUri() const {
+        if (type == ObjectRefType::URI) {
+            return value;
+        } else {
+            return EMPTY_STRING;
+        }
+    }
+
+    void ExternalObjectReference::setName(const std::string& name) {
+        type = ObjectRefType::NAME;
+        value = name;
+    }
+
+    void ExternalObjectReference::setUri(const std::string& uri) {
+        type = ObjectRefType::URI;
+        value = uri;
     }
 
     ExternalReference::ExternalReference(std::string const& id) : Object(id) {

--- a/sources/src/citygml/geometry.cpp
+++ b/sources/src/citygml/geometry.cpp
@@ -20,7 +20,7 @@ namespace citygml {
 
     unsigned int Geometry::getPolygonsCount() const
     {
-        return m_polygons.size();
+        return static_cast<unsigned int>(m_polygons.size());
     }
 
     std::shared_ptr<Polygon> Geometry::getPolygon(unsigned int i)
@@ -35,7 +35,7 @@ namespace citygml {
 
     unsigned int Geometry::getLineStringCount() const
     {
-        return m_lineStrings.size();
+        return static_cast<unsigned int>(m_lineStrings.size());
     }
 
     std::shared_ptr<LineString> Geometry::getLineString(unsigned int i)
@@ -50,7 +50,7 @@ namespace citygml {
 
     unsigned int Geometry::getGeometriesCount() const
     {
-        return m_childGeometries.size();
+        return static_cast<unsigned int>(m_childGeometries.size());
     }
 
     const Geometry& Geometry::getGeometry(unsigned int i) const
@@ -164,7 +164,7 @@ namespace citygml {
         for ( unsigned int i = 0; i < s.getPolygonsCount(); i++ )
         {
             os << s.getPolygon(i);
-            count += s.getPolygon(i)->getVertices().size();
+            count += static_cast<unsigned int>(s.getPolygon(i)->getVertices().size());
         }
 
         os << "  @ " << s.getPolygonsCount() << " polys [" << count << " vertices]" << std::endl;

--- a/sources/src/citygml/implictgeometry.cpp
+++ b/sources/src/citygml/implictgeometry.cpp
@@ -35,7 +35,7 @@ namespace citygml {
 
     unsigned int ImplicitGeometry::getGeometriesCount() const
     {
-        return m_geometries.size();
+        return static_cast<unsigned int>(m_geometries.size());
     }
 
     Geometry& ImplicitGeometry::getGeometry(unsigned int i) const

--- a/sources/src/citygml/linearring.cpp
+++ b/sources/src/citygml/linearring.cpp
@@ -20,7 +20,7 @@ namespace citygml {
 
     unsigned int LinearRing::size() const
     {
-        return m_vertices.size();
+        return static_cast<unsigned int>(m_vertices.size());
     }
 
     void LinearRing::addVertex(const TVec3d& v)
@@ -91,7 +91,7 @@ namespace citygml {
         }
 
         // Remove duplicated vertex
-        unsigned int len = m_vertices.size();
+        unsigned int len = static_cast<unsigned int>(m_vertices.size());
         if ( len < 2 ) return;
 
         unsigned int i = 0;

--- a/sources/src/citygml/tesselator.cpp
+++ b/sources/src/citygml/tesselator.cpp
@@ -87,7 +87,7 @@ void Tesselator::processContours()
         for ( unsigned int i = 0; i < contour.length; i++ )
         {
             void* data = reinterpret_cast<void*>(static_cast<uintptr_t>(_indices[contour.index + i]));
-            gluTessVertex( _tobj, &(_originalVertices[contour.index + i][0]), data );
+            gluTessVertex( _tobj, &(_originalVertices[contour.index + i].x), data );
         }
 
         gluTessEndContour( _tobj );

--- a/sources/src/citygml/tesselator.cpp
+++ b/sources/src/citygml/tesselator.cpp
@@ -67,10 +67,10 @@ void Tesselator::compute()
 
 void Tesselator::addContour(const std::vector<TVec3d>& pts, std::vector<std::vector<TVec2f> > textureCoordinatesLists )
 {
-    unsigned int pos = _vertices.size();
+    unsigned int pos = static_cast<unsigned int>(_vertices.size());
     TesselatorBase::addContour(pts, textureCoordinatesLists);
 
-    unsigned int len = pts.size();
+    unsigned int len = static_cast<unsigned int>(pts.size());
     // Add contour to queue, and process later.
     ContourRef contour(pos, len);
     _contourQueue.push_back(contour);
@@ -115,7 +115,7 @@ void CALLBACK Tesselator::vertexDataCallback( GLvoid *data, void* userData )
 void CALLBACK Tesselator::combineCallback( GLdouble coords[3], void* vertex_data[4], GLfloat weight[4], void** outData, void* userData )
 {
     Tesselator *tess = static_cast<Tesselator*>(userData);
-    tess->_indices.push_back(tess->_indices.size());
+    tess->_indices.push_back(static_cast<unsigned int>(tess->_indices.size()));
     tess->_vertices.push_back( TVec3d( coords[0], coords[1], coords[2] ) );
 
     if (!tess->_texCoordsLists.empty()) {
@@ -149,7 +149,7 @@ void CALLBACK Tesselator::endCallback( void* userData )
 {
     Tesselator *tess = static_cast<Tesselator*>(userData);
 
-    unsigned int len = tess->_curIndices.size();
+    unsigned int len = static_cast<unsigned int>(tess->_curIndices.size());
 
     switch ( tess->_curMode )
     {

--- a/sources/src/citygml/tesselatorbase.cpp
+++ b/sources/src/citygml/tesselatorbase.cpp
@@ -80,7 +80,7 @@ bool TesselatorBase::keepVertices() const
 
 void TesselatorBase::addContour(const std::vector<TVec3d>& pts, std::vector<std::vector<TVec2f> > textureCoordinatesLists )
 {
-    unsigned int len = pts.size();
+    unsigned int len = static_cast<unsigned int>(pts.size());
     if ( len < 3 ) return;
 
     for (size_t i = 0; i < textureCoordinatesLists.size(); i++) {
@@ -113,7 +113,7 @@ void TesselatorBase::addContour(const std::vector<TVec3d>& pts, std::vector<std:
 
     }
 
-    unsigned int pos = _vertices.size();
+    unsigned int pos = static_cast<unsigned int>(_vertices.size());
 
     for ( unsigned int i = 0; i < len; i++ )
     {

--- a/sources/src/citygml/texturetargetdefinition.cpp
+++ b/sources/src/citygml/texturetargetdefinition.cpp
@@ -9,7 +9,7 @@ namespace citygml {
 
     unsigned int TextureTargetDefinition::getTextureCoordinatesCount() const
     {
-        return m_coordinatesList.size();
+        return static_cast<unsigned int>(m_coordinatesList.size());
     }
 
     std::shared_ptr<TextureCoordinates> TextureTargetDefinition::getTextureCoordinates(unsigned int i)

--- a/sources/src/parser/externalreferenceparser.cpp
+++ b/sources/src/parser/externalreferenceparser.cpp
@@ -60,9 +60,9 @@ namespace citygml {
         } else if (node == NodeType::CORE_InformationSystemNode) {
             model->informationSystem = characters;
         } else if (node == NodeType::CORE_NameNode) {
-            model->externalObject.name = characters;
+            model->externalObject.setName(characters);
         } else if (node == NodeType::CORE_UriNode) {
-            model->externalObject.uri = characters;
+            model->externalObject.setUri(characters);
         }
         
         return GMLObjectElementParser::parseChildElementEndTag(node, characters);

--- a/sources/src/parser/geometryelementparser.cpp
+++ b/sources/src/parser/geometryelementparser.cpp
@@ -89,7 +89,7 @@ namespace citygml {
     bool GeometryElementParser::parseElementEndTag(const NodeType::XMLNode&, const std::string&)
     {
         if (m_orientation == "-") {
-            for (int i = 0; i < m_model->getPolygonsCount(); i++) {
+            for (unsigned int i = 0; i < m_model->getPolygonsCount(); i++) {
                 m_model->getPolygon(i)->setNegNormal(true);
             }
         }

--- a/test/citygmltest.cpp
+++ b/test/citygmltest.cpp
@@ -92,7 +92,7 @@ int main( int argc, char **argv )
 #endif // LIBCITYGML_USE_OPENGL
     try{
         city = citygml::load( argv[fargc], params, std::move(tesselator) );
-    }catch(const std::runtime_error& e){
+    }catch(const std::runtime_error&){
         
     }
 #endif


### PR DESCRIPTION
Some structs and unions currently don't adhere to the C++ standard.
They rely solely on the compiler implementation doing what we expect it to do.

This PR fixes the elements that don't adhere to the C++ standard.

Only the last to commits are actually part of this PR. All the others are from PR #99 but not basing this PR on that one would lead to conflicts when merging.