### PR TITLE
Fix build with gcc-15

### DIFF
--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -9,6 +9,7 @@
 #include <citygml/rectifiedgridcoverage.h>
 #include <citygml/externalreference.h>
 #include <citygml/warnings.h>
+#include <cstdint>
 class TesselatorBase;
 
 namespace citygml {


### PR DESCRIPTION
The builds are failing with the error:

```
/<<PKGBUILDDIR>>/sources/include/citygml/cityobject.h:27:38: error: ‘uint64_t’ was not declared in this scope
   27 |         enum class CityObjectsType : uint64_t {
      |                                      ^~~~~~~~
/<<PKGBUILDDIR>>/sources/include/citygml/cityobject.h:11:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   10 | #include <citygml/externalreference.h>
  +++ |+#include <cstdint>
   11 | class TesselatorBase;
 ```
The full log can be seen at https://launchpadlibrarian.net/833440354/buildlog_ubuntu-resolute-amd64.libcitygml_2.5.2-1build6_BUILDING.txt.gz